### PR TITLE
Fix: point all the Cocoapods podspecs to proper documentation site.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The change log has moved to this repo's [GitHub Releases Page](https://github.co
 
 ## Release Notes
 
+**2.0.0-beta8**
+- fix: point all the Cocoapods podspecs to proper documentation site.
+
 **2.0.0-beta7**
 **2.0.0-beta6**
 **2.0.0-beta5**

--- a/RollbarCommon.podspec
+++ b/RollbarCommon.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
 
-    s.version      = "2.0.0-beta7"
+    s.version      = "2.0.0-beta8"
     s.name         = "RollbarCommon"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     # s.license      = "MIT (example)"
-    s.documentation_url = "https://docs.rollbar.com/docs/ios"
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # s.author             = { "Andrey Kornich" => "akornich@gmail.com" }

--- a/RollbarDeploys.podspec
+++ b/RollbarDeploys.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
 
-    s.version      = "2.0.0-beta7"
+    s.version      = "2.0.0-beta8"
     s.name         = "RollbarDeploys"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     # s.license      = "MIT (example)"
-    s.documentation_url = "https://docs.rollbar.com/docs/ios"
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # s.author             = { "Andrey Kornich" => "akornich@gmail.com" }

--- a/RollbarKSCrash.podspec
+++ b/RollbarKSCrash.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
 
-    s.version      = "2.0.0-beta7"
+    s.version      = "2.0.0-beta8"
     s.name         = "RollbarKSCrash"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     # s.license      = "MIT (example)"
-    s.documentation_url = "https://docs.rollbar.com/docs/ios"
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # s.author             = { "Andrey Kornich" => "akornich@gmail.com" }

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
 
-    s.version      = "2.0.0-beta7"
+    s.version      = "2.0.0-beta8"
     s.name         = "RollbarNotifier"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     # s.license      = "MIT (example)"
-    s.documentation_url = "https://docs.rollbar.com/docs/ios"
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # s.author             = { "Andrey Kornich" => "akornich@gmail.com" }

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarConfig.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarConfig.m
@@ -22,7 +22,7 @@
 
 #pragma mark - constants
 
-static NSString * const NOTIFIER_VERSION = @"2.0.0-beta7";
+static NSString * const NOTIFIER_VERSION = @"2.0.0-beta8";
 
 static NSString * const NOTIFIER_NAME = @"rollbar-apple";
 

--- a/RollbarPLCrashReporter.podspec
+++ b/RollbarPLCrashReporter.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
 
-    s.version      = "2.0.0-beta7"
+    s.version      = "2.0.0-beta8"
     s.name         = "RollbarPLCrashReporter"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     # s.license      = "MIT (example)"
-    s.documentation_url = "https://docs.rollbar.com/docs/ios"
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # s.author             = { "Andrey Kornich" => "akornich@gmail.com" }

--- a/RollbarSDK.experimental_podspec
+++ b/RollbarSDK.experimental_podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |sdk|
 
     # Rollbar SDK:
     # ============
-    sdk.version      = "2.0.0-beta7"
+    sdk.version      = "2.0.0-beta8"
     sdk.name         = "RollbarSDK"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     sdk.description  = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |sdk|
     # sdk.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     sdk.license      = { :type => "MIT", :file => "LICENSE" }
     # sdk.license      = "MIT (example)"
-    sdk.documentation_url = "https://docs.rollbar.com/docs/ios"
+    sdk.documentation_url = "https://docs.rollbar.com/docs/apple"
     sdk.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # sdk.author             = { "Andrey Kornich" => "akornich@gmail.com" }

--- a/RollbarSwift.podspec
+++ b/RollbarSwift.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
 
-    s.version      = "2.0.0-beta7"
+    s.version      = "2.0.0-beta8"
     s.name         = "RollbarSwift"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     # s.license      = "MIT (example)"
-    s.documentation_url = "https://docs.rollbar.com/docs/ios"
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.authors            = { "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
                               "Rollbar" => "support@rollbar.com" }
     # s.author             = { "Andrey Kornich" => "akornich@gmail.com" }


### PR DESCRIPTION
## Description of the change

> - fix: point all the Cocoapods podspecs to proper documentation site.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> n/a

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
