### PR TITLE
Remove invalid platforms property from target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,9 +104,6 @@ let package = Package(
         .target(
             name: "RollbarAUL",
             dependencies: ["RollbarCommon", "RollbarNotifier"],
-            platforms: [
-                .macOS(.v10_15),
-            ],
             path: "RollbarAUL/Sources/RollbarAUL",
             publicHeadersPath: "include",
             cSettings: [


### PR DESCRIPTION
## Description of the change

A fix for issue  #88 where an invalid platforms key crept into the master branch.

Removed invalid `platforms` key from the `RollbarAUL` target.

(Originally identified by @RickPasveer) 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#88]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
