### PR TITLE
Failsafe to ensure obj is not nil when creating dict literal

### DIFF
--- a/RollbarCommon/Sources/RollbarCommon/NSJSONSerialization+Rollbar.m
+++ b/RollbarCommon/Sources/RollbarCommon/NSJSONSerialization+Rollbar.m
@@ -50,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     [obj enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        // Defensive failsafe to avoid exceptions when trying to create dictionary literal with nil `obj`
+        obj = obj ?: [NSNull null];
         
         if ([obj isKindOfClass:[NSDictionary class]]) {
             

--- a/RollbarCommon/Tests/RollbarCommonTests/NSJSONSerialization+RollbarTests.swift
+++ b/RollbarCommon/Tests/RollbarCommonTests/NSJSONSerialization+RollbarTests.swift
@@ -33,10 +33,12 @@ final class NSJSONSerializationRollbarTests: XCTestCase {
     func testNSJSONSerializationRollbar_safeDataFromJSONObject() {
                 
         let goldenStandard =
-            "{\"access_token\":\"321\",\"data\":{\"attribute\":\"An attribute\",\"body\":\"Message\",\"date\":\"1970-01-01 00:00:00 +0000\",\"error\":{},\"httpUrlResponse\":{\"header1\":\"Header 1\",\"header2\":\"Header 2\"},\"innerData\":{\"attribute\":\"An attribute\",\"body\":\"Message\",\"date\":\"1970-01-01 00:00:00 +0000\",\"error\":{},\"httpUrlResponse\":{\"header1\":\"Header 1\",\"header2\":\"Header 2\"},\"scrubFields\":\"secret,CCV,password\",\"url\":\"http:\\/\\/www.apple.com\"},\"scrubFields\":\"secret,CCV,password\",\"url\":\"http:\\/\\/www.apple.com\"}}";
-        
+            "{\"access_token\":\"321\",\"data\":{\"attribute\":\"An attribute\",\"body\":\"Message\",\"date\":\"1970-01-01 00:00:00 +0000\",\"error\":{},\"httpUrlResponse\":{\"header1\":\"Header 1\",\"header2\":\"Header 2\"},\"innerData\":{\"attribute\":\"An attribute\",\"body\":\"Message\",\"date\":\"1970-01-01 00:00:00 +0000\",\"error\":{},\"httpUrlResponse\":{\"header1\":\"Header 1\",\"header2\":\"Header 2\"},\"optionalField\":null,\"scrubFields\":\"secret,CCV,password\",\"url\":\"http:\\/\\/www.apple.com\"},\"optionalField\":null,\"scrubFields\":\"secret,CCV,password\",\"url\":\"http:\\/\\/www.apple.com\"}}";
+
+        let optionalFieldValue: String? = nil
         var data = [
             "body": "Message",
+            "optionalField": optionalFieldValue as Any,
             "attribute": "An attribute",
             "date": NSDate.init(timeIntervalSince1970: TimeInterval.init()),
             "url": NSURL.init(string: "http://www.apple.com")!,


### PR DESCRIPTION
## Description of the change

This PR adds a defensive failsafe to ensure that object is not nil while serializing it. In case of nil, Foundation throws the following exception: `-[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]`. 

My first assumption was that this might happen due to implicit coercing of Swift's optional values to `the Any` type. For this, I have added a test case with a nil optional string. However, this worked as expected, resulting in a JSON with a `null` values added and no exception thrown. 

To reproduce the error, I hardcoded `obj` to nil in the following way: 
```Swift
    [obj enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
        // Hardcoded here
        obj = nil;
        
        if ([obj isKindOfClass:[NSDictionary class]]) {
            
            [safeData setObject:[[self class] rollbar_safeDataFromJSONObject:obj] forKey:key];
        } else if ([obj isKindOfClass:[NSArray class]]) {
            
            [safeData setObject:((NSArray *)obj).mutableCopy forKey:key];
        } else if ([NSJSONSerialization isValidJSONObject:@{key:obj}]) {
```
Then I could get an exception. Additionally I also tried to play with different objects and dictionaries containing nil values, but could not trigger exceptions. 

This change might not be conceptually correct since the nil value's root cause is unclear. However, a defensive fix is a small price for not crashing the app. 

> _Thinking out loud_: Considering that the exception is not happening every time, the issue might suggest some race condition issues. Dictionaries are not thread safe, and if the dictionary is modified during enumeration, this could cause this exception. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fixes https://github.com/rollbar/rollbar-apple/issues/215

## Checklists

### Development

* I could not figure out how to run linting
* I'm not sure how to simulate the use case where the dictionary contains nil objects, so I only covered existing use case with a test 

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
