### PR TITLE
Crash while serializing data into JSON.

### DIFF
--- a/RollbarCommon/Sources/RollbarCommon/DTOs/RollbarDTO.m
+++ b/RollbarCommon/Sources/RollbarCommon/DTOs/RollbarDTO.m
@@ -363,7 +363,7 @@
     }
     
     if (![RollbarDTO isTransferableObject:data]) {
-        
+        RollbarSdkLog(@"JSON-invalid internal data.");
         return self;
     }
     

--- a/RollbarCommon/Tests/RollbarCommonTests/NSJSONSerialization+RollbarTests.swift
+++ b/RollbarCommon/Tests/RollbarCommonTests/NSJSONSerialization+RollbarTests.swift
@@ -31,53 +31,41 @@ final class NSJSONSerializationRollbarTests: XCTestCase {
     }
     
     func testNSJSONSerializationRollbar_safeDataFromJSONObject() {
-                
         let goldenStandard =
             "{\"access_token\":\"321\",\"data\":{\"attribute\":\"An attribute\",\"body\":\"Message\",\"date\":\"1970-01-01 00:00:00 +0000\",\"error\":{},\"httpUrlResponse\":{\"header1\":\"Header 1\",\"header2\":\"Header 2\"},\"innerData\":{\"attribute\":\"An attribute\",\"body\":\"Message\",\"date\":\"1970-01-01 00:00:00 +0000\",\"error\":{},\"httpUrlResponse\":{\"header1\":\"Header 1\",\"header2\":\"Header 2\"},\"optionalField\":null,\"scrubFields\":\"secret,CCV,password\",\"url\":\"http:\\/\\/www.apple.com\"},\"optionalField\":null,\"scrubFields\":\"secret,CCV,password\",\"url\":\"http:\\/\\/www.apple.com\"}}";
 
-        let optionalFieldValue: String? = nil
         var data = [
             "body": "Message",
-            "optionalField": optionalFieldValue as Any,
+            "optionalField": (nil as String?) as Any,
             "attribute": "An attribute",
-            "date": NSDate.init(timeIntervalSince1970: TimeInterval.init()),
-            "url": NSURL.init(string: "http://www.apple.com")!,
-            "error": NSError.init(domain: "Error Domain", code: 101, userInfo: nil),
-            "httpUrlResponse": HTTPURLResponse.init(
-                url: URL.init(string: "https://www.rollbar.com")!,
+            "date": Date(timeIntervalSince1970: TimeInterval.init()),
+            "url": URL(string: "http://www.apple.com")!,
+            "error": NSError(domain: "Error Domain", code: 101, userInfo: nil),
+            "httpUrlResponse": HTTPURLResponse(
+                url: URL(string: "https://www.rollbar.com")!,
                 statusCode: 500,
                 httpVersion: "1.2",
                 headerFields: ["header1": "Header 1", "header2": "Header 2"]) as Any,
-            "scrubFields": NSSet.init(array: ["password", "secret", "CCV"]),
-            ] as [String : Any];
-        
-        if #available(OSX 10.13, iOS 11.0, *) {
-            data["innerData"] = JSONSerialization.rollbar_data(
-                withJSONObject: data,
-                options: .sortedKeys,
-                error: nil,
-                safe: true)
-        } else {
-            // Fallback on earlier versions
-            XCTFail("Test it on more recent OS version!");
-        };
+            "scrubFields": NSSet(array: ["password", "secret", "CCV"]),
+        ] as [String: Any];
+
+        data["innerData"] = JSONSerialization.rollbar_data(
+            withJSONObject: data,
+            options: .sortedKeys,
+            error: nil,
+            safe: true)
 
         let payload = [
             "access_token": "321",
             "data": data,
-            ] as [String : Any];
-        
+        ] as [String : Any];
+
         let safeJson = JSONSerialization.rollbar_safeData(fromJSONObject: payload);
 
         do {
-            if #available(OSX 10.13, iOS 11.0, *) {
-                let jsonData = try JSONSerialization.data(withJSONObject: safeJson, options: .sortedKeys)
-                let result = String.init(data: jsonData, encoding: .utf8);
-                XCTAssertEqual(goldenStandard, result);
-            } else {
-                // Fallback on earlier versions
-                XCTFail("Test it on more recent OS version!");
-            };
+            let jsonData = try JSONSerialization.data(withJSONObject: safeJson, options: .sortedKeys)
+            let result = String(data: jsonData, encoding: .utf8);
+            XCTAssertEqual(goldenStandard, result);
         }
         catch {
             XCTFail("Unexpected failure!");


### PR DESCRIPTION
## Description of the change

This PR adds a low-level layer of protection to the serialization component of Rollbar to avoid a rare crash where the received raw input to be serialized is not an `NSObject`, but either a primitive or an unserializable Swift type (eg. a tuple).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix [119439](https://app.shortcut.com/rollbar/story/119439/apple-sdk-crash-reported-by-duolingo)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
