### PR TITLE
If there's no diagnostic, fallback to exception type.

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadFactory.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadFactory.m
@@ -297,12 +297,30 @@
     return self.osData;
 }
 
-- (nonnull NSString *)messageFromCrashReport:(nonnull NSString *)crashReport {
-    NSRange range = [crashReport rangeOfString:@"CrashDoctor Diagnosis: " options:NSBackwardsSearch];
-    NSUInteger start = range.location + range.length;
-    range = NSMakeRange(start, crashReport.length - start);
+- (nonnull NSString *)messageFromCrashReport:(nonnull NSString *)report {
+    NSRange range = [report rangeOfString:@"CrashDoctor Diagnosis: "
+                                       options:NSBackwardsSearch];
+    if (range.length != 0) {
+        NSUInteger start = range.location + range.length;
+        range = NSMakeRange(start, report.length - start);
+        return [self diagnosticFromFromCrashReport:report range:range];
+    }
+
+    range = [report rangeOfString:@"Exception Type:"];
+    if (range.length != 0) {
+        NSRange lineRange = [report lineRangeForRange:range];
+        lineRange.location += range.length;
+        lineRange.length -= range.length;
+        return [self diagnosticFromFromCrashReport:report range:lineRange];
+    }
+}
+
+- (nonnull NSString *)diagnosticFromFromCrashReport:(nonnull NSString *)crashReport
+                                              range:(NSRange)range
+{
     NSString *diagnosis = [crashReport substringWithRange:range];
     diagnosis = [diagnosis stringByReplacingOccurrencesOfString:@"\n" withString:@" "];
+    diagnosis = [diagnosis stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     RollbarSdkLog(@"%@", diagnosis);
     return diagnosis;
 }


### PR DESCRIPTION
## Description of the change

Not all OS crash reports can be diagnosed, especially crashes that originate in Swift code, and that are due to Swift language features, for example force unwrapping a nil optional, a forcefully assuming that a try/catch block always succeeds but then it doesn't, an invalid downcasting, and others.

We'll fallback to the exception type found in the OS crash report in these cases.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix [121443](https://app.shortcut.com/rollbar/story/121443/apple-sdk-fix-items-with-unknown-title-coming-from-some-swift-related-crashes)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
