### PR TITLE
Never symbolicate main executable frames.

### DIFF
--- a/RollbarNotifier/Sources/RollbarCrashReport/Formatter/RollbarCrashFormattingFilter.swift
+++ b/RollbarNotifier/Sources/RollbarCrashReport/Formatter/RollbarCrashFormattingFilter.swift
@@ -262,7 +262,7 @@ fileprivate extension RollbarCrashFormattingFilter {
                 case let .instruction(addr):
                     "\(index) \("?".pad(31)) \(addr) ? + \(addr.value)"
 
-                case let .unsymbolicated(frame):
+                case let .symbolicated(frame) where frame.object.name == process:
                     let preamble = "\(index) \(frame.object.name.pad(31)) \(frame.instructionAddr)"
                     let offset = frame.instructionAddr - frame.object.addr.value
                     "\(preamble) \(frame.object.addr) + \(offset.value)"
@@ -271,6 +271,11 @@ fileprivate extension RollbarCrashFormattingFilter {
                     let preamble = "\(index) \(frame.object.name.pad(31)) \(frame.instructionAddr)"
                     let offset = frame.instructionAddr - frame.symbol.addr.value
                     "\(preamble) \(frame.symbol.name) + \(offset.value)"
+
+                case let .unsymbolicated(frame):
+                    let preamble = "\(index) \(frame.object.name.pad(31)) \(frame.instructionAddr)"
+                    let offset = frame.instructionAddr - frame.object.addr.value
+                    "\(preamble) \(frame.object.addr) + \(offset.value)"
                 }
             }
         }


### PR DESCRIPTION
## Description of the change
Prevents the internal symbolication from writing symbols instead of addresses for frames that belong to the main executable.

We want these to be fully symbolicated server-side as it is not possible to do it client-side.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

This is one of the fixes described in:
- [119921](https://app.shortcut.com/rollbar/story/119921/apple-back-symbolicate-stack-traces-in-crash-reports)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
