### PR TITLE
Fixed cpu subtype not being correctly identified

### DIFF
--- a/RollbarNotifier/Sources/RollbarCrashReport/Formatter/RollbarCrashFormattingFilter.swift
+++ b/RollbarNotifier/Sources/RollbarCrashReport/Formatter/RollbarCrashFormattingFilter.swift
@@ -321,11 +321,11 @@ fileprivate extension RollbarCrashFormattingFilter {
     func binaryImages(for report: Report) -> Formatted<String> {
         .init {
             "\nBinary Images:"
-            for img in report.binaryImages.sorted(by: their(\.addr.0)) {
+            for img in report.binaryImages.sorted(by: their(\.addr.start)) {
                 let cpu = img.cpu.subtypeName
                 let uuid = img.uuid.uuidString.replacingOccurrences(of: "-", with: "").lowercased()
                 let isMain = img.path == report.system.bundleExecutablePath ? "+" : " "
-                "\(img.addr.0) - \(img.addr.1) \(isMain)\(img.name) \(cpu)  <\(uuid)> \(img.path.absoluteString)"
+                "\(img.addr.start) - \(img.addr.end) \(isMain)\(img.name) \(cpu)  <\(uuid)> \(img.path.absoluteString)"
             }
         }
     }

--- a/RollbarNotifier/Sources/RollbarCrashReport/Report/BinaryImage.swift
+++ b/RollbarNotifier/Sources/RollbarCrashReport/Report/BinaryImage.swift
@@ -29,7 +29,7 @@ struct BinaryImage: RawRepresentable {
 
     /// A tuple holding the starting and ending address pointing to
     /// the location of the symbols within the debug information file (dSYM/DWARF).
-    let addr: (Address, Address)
+    let addr: (start: Address, end: Address)
 
     /// The VM address where this binary was located in memory.
     let vmaddr: Address

--- a/RollbarNotifier/Sources/RollbarCrashReport/Report/CPU.swift
+++ b/RollbarNotifier/Sources/RollbarCrashReport/Report/CPU.swift
@@ -14,8 +14,7 @@ struct CPU {
         case CPU_TYPE_ARM: return "ARM"
         case CPU_TYPE_ARM64: return "ARM-64"
         case CPU_TYPE_ARM64_32: return "ARM-64_32"
-        case CPU_TYPE_X86: return "X86"
-        case CPU_TYPE_I386: return "I386"
+        case CPU_TYPE_X86 | CPU_TYPE_I386: return "X86"
         case CPU_TYPE_X86_64: return "X86-64"
         case _: return "UNKNOWN"
         }
@@ -23,31 +22,34 @@ struct CPU {
 
     /// A crash reporting appropriate formatted String of the specific architecture.
     var subtypeName: String {
-        switch (type, subtype) {
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V6): return "armv6"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7): return "armv7"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7F): return "armv7f"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7S): return "armv7s"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7K): return "armv7k"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7M): return "armv7m"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7EM): return "armv7em"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V8): return "armv8"
-        case (CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V8M): return "armv8"
-        case (CPU_TYPE_ARM, _): return "arm"
-
-        case (CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64E): return "arm64e"
-        case (CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_V8): return "arm64v8"
-        case (CPU_TYPE_ARM64, _): return "arm64"
-
-        case (CPU_TYPE_ARM64_32, CPU_SUBTYPE_ARM64_32_V8): return "arm64_32v8"
-        case (CPU_TYPE_ARM64_32, _): return "arm64_32"
-
-        case (CPU_TYPE_X86, _): return "x86"
-        case (CPU_TYPE_I386, _): return "i386"
-        case (CPU_TYPE_X86_64, _): return "x86_64"
-
-        case let (type, subtype):
-            return "unknown(\(type), \(subtype))"
+        switch self.type {
+        case CPU_TYPE_ARM:
+            return [
+                (mask: CPU_SUBTYPE_ARM_V6, name: "armv6"),
+                (mask: CPU_SUBTYPE_ARM_V7, name: "armv7"),
+                (mask: CPU_SUBTYPE_ARM_V7F, name: "armv7f"),
+                (mask: CPU_SUBTYPE_ARM_V7S, name: "armv7s"),
+                (mask: CPU_SUBTYPE_ARM_V7K, name: "armv7k"),
+                (mask: CPU_SUBTYPE_ARM_V7M, name: "armv7m"),
+                (mask: CPU_SUBTYPE_ARM_V7EM, name: "armv7em"),
+                (mask: CPU_SUBTYPE_ARM_V8, name: "armv8"),
+                (mask: CPU_SUBTYPE_ARM_V8M, name: "armv8m")
+            ].first(where: { self.subtype & $0.mask == $0.mask })?.name ?? "arm"
+        case CPU_TYPE_ARM64:
+            return [
+                (mask: CPU_SUBTYPE_ARM64_V8, name: "arm64v8"),
+                (mask: CPU_SUBTYPE_ARM64E, name: "arm64e")
+            ].first(where: { self.subtype & $0.mask == $0.mask })?.name ?? "arm64"
+        case CPU_TYPE_ARM64_32:
+            return [
+                (mask: CPU_SUBTYPE_ARM64_32_V8, name: "arm64_32v8"),
+            ].first(where: { self.subtype & $0.mask == $0.mask })?.name ?? "arm64_32"
+        case CPU_TYPE_X86 | CPU_TYPE_I386:
+            return "x86"
+        case CPU_TYPE_X86_64:
+            return "x86_64"
+        case _:
+            return "unknown"
         }
     }
 
@@ -95,5 +97,17 @@ struct CPU {
         case _:
             return []
         }
+    }
+}
+
+extension CPU: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        """
+        CPU (\(self.typeName), \(self.subtypeName)) {
+            type:    \(self.type)
+            subtype: \(self.subtype)
+        }
+        """
     }
 }


### PR DESCRIPTION
## Description of the change
CPU subtype wasn't being correctly identified, so the architecture of each library in the binary images section of the crash report was being incorrectly set.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- [119921](https://app.shortcut.com/rollbar/story/119921/apple-back-symbolicate-stack-traces-in-crash-reports)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
