### PR TITLE
Allow users to change access token from the Demo UI.

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Demos/iosAppSwift/iosAppSwift.xcodeproj/project.pbxproj
+++ b/Demos/iosAppSwift/iosAppSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B24660A29C37CEA0078C74F /* Prelude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B24660929C37CEA0078C74F /* Prelude.swift */; };
 		3BDB8240292D2DCE0093AC9D /* iosAppSwiftApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDB823F292D2DCE0093AC9D /* iosAppSwiftApp.swift */; };
 		3BDB8242292D2DCE0093AC9D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDB8241292D2DCE0093AC9D /* ContentView.swift */; };
 		3BDB8244292D2DCF0093AC9D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3BDB8243292D2DCF0093AC9D /* Assets.xcassets */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3B24660929C37CEA0078C74F /* Prelude.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prelude.swift; sourceTree = "<group>"; };
 		3BDB823C292D2DCE0093AC9D /* iosAppSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosAppSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BDB823F292D2DCE0093AC9D /* iosAppSwiftApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosAppSwiftApp.swift; sourceTree = "<group>"; };
 		3BDB8241292D2DCE0093AC9D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -60,6 +62,7 @@
 				3BDB8241292D2DCE0093AC9D /* ContentView.swift */,
 				3BDB8243292D2DCF0093AC9D /* Assets.xcassets */,
 				3BDB8245292D2DCF0093AC9D /* Preview Content */,
+				3B24660929C37CEA0078C74F /* Prelude.swift */,
 			);
 			path = iosAppSwift;
 			sourceTree = "<group>";
@@ -153,6 +156,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B24660A29C37CEA0078C74F /* Prelude.swift in Sources */,
 				3BDB8242292D2DCE0093AC9D /* ContentView.swift in Sources */,
 				3BDB8240292D2DCE0093AC9D /* iosAppSwiftApp.swift in Sources */,
 			);
@@ -281,7 +285,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_ASSET_PATHS = "\"iosAppSwift/Preview Content\"";
 				DEVELOPMENT_TEAM = 6B5NER795L;
 				ENABLE_PREVIEWS = YES;
@@ -292,11 +296,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.matux.test.rollbarAppDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -311,7 +316,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 35;
 				DEVELOPMENT_ASSET_PATHS = "\"iosAppSwift/Preview Content\"";
 				DEVELOPMENT_TEAM = 6B5NER795L;
 				ENABLE_PREVIEWS = YES;
@@ -322,11 +327,12 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.matux.test.rollbarAppDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Demos/iosAppSwift/iosAppSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Demos/iosAppSwift/iosAppSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>

--- a/Demos/iosAppSwift/iosAppSwift/Prelude.swift
+++ b/Demos/iosAppSwift/iosAppSwift/Prelude.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension String {
+    var isValid: Bool {
+        #"(^[a-f0-9]{32}$)"#.matches(in: self)?.count == 1
+    }
+}
+
+extension StringProtocol {
+
+    /// Returns an array of `Substring`s by matching the given `String` using
+    /// this string as a regular expression pattern.
+    ///
+    /// Returns `nil` if this string isn't a valid regex pattern, if no
+    /// matches are found, an empty string is returned.
+    func matches(in str: String) -> [Substring]? {
+        let regex = try? NSRegularExpression(pattern: String(self))
+        let range = NSRange(str.startIndex..<str.endIndex, in: str)
+        return regex?.matches(in: str, range: range).first?.groups(in: str)
+    }
+}
+
+extension NSTextCheckingResult {
+
+    /// Returns an array of `Substring`s by extracting from the given `String`
+    /// the groups in this `NSTextCheckingResult` instance .
+    func groups(in str: String) -> [Substring] {
+        guard self.numberOfRanges > 1 else { return [] }
+
+        var result = ContiguousArray<Substring>()
+        result.reserveCapacity(self.numberOfRanges)
+
+        for index in 1..<self.numberOfRanges {
+            if let substr = range(at: index, in: str).map({ str[$0] }) {
+                result.append(substr)
+            }
+        }
+
+        return [Substring](result)
+    }
+
+    /// Returns the `Range` for the given group number that corresponds to
+    /// the given `String`.
+    func range(at index: Int, in string: String) -> Range<String.Index>? {
+        Range(self.range(at: index), in: string)
+    }
+}

--- a/Demos/iosAppSwift/iosAppSwift/iosAppSwiftApp.swift
+++ b/Demos/iosAppSwift/iosAppSwift/iosAppSwiftApp.swift
@@ -14,13 +14,14 @@ struct iosAppSwiftApp: App {
 }
 
 class AppDelegate: NSObject, UIApplicationDelegate {
+    @AppStorage("rollbar_post_client_item_access_token") var accessToken = ""
 
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
         // Dynamically read these settings from your config settings on application startup.
-        let accessToken = "YOUR-ROLLBAR-TOKEN"  // Rollbar post_client_item access token
+        let accessToken = self.accessToken // Rollbar post_client_item access token
         let environment = "staging"
         let codeVersion = "main"  // Ideally codeVersion is commit SHA https://docs.rollbar.com/docs/versions
 


### PR DESCRIPTION
## Description of the change

Users can now change the access token for the project the Swift iOS Demo uses.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Addresses [123810](https://app.shortcut.com/rollbar/story/123810/apple-sdk-allow-modifying-the-access-token-in-demo)
- Partially unblocks [119952](https://app.shortcut.com/rollbar/story/119952/apple-sdk-streamline-testing-different-application-environments)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
