### PR TITLE
Fixed failing crash report test after removing mach diagnosis collection

### DIFF
--- a/RollbarNotifier/Tests/RollbarCrashReportTests/Assets/report.crash
+++ b/RollbarNotifier/Tests/RollbarCrashReportTests/Assets/report.crash
@@ -57,8 +57,8 @@ Thread 0 Crashed:
 3   libswiftCore.dylib              0x000000018bd55564 _assertionFailure(_:_:file:line:flags:) + 228
 4   libswiftCore.dylib              0x000000018bd36eb8 _ArrayBuffer._checkInoutAndNativeTypeCheckedBounds(_:wasNativeTypeChecked:) + 276
 5   libswiftCore.dylib              0x000000018bd3abf0 Array.subscript.getter + 84
-6   iosAppSwift                     0x0000000104733590 Example.outOfBounds() + 72
-7   iosAppSwift                     0x000000010473353c $s11iosAppSwift11ContentViewV4bodyQrvg0C2UI05TupleE0VyAE0E0PAEE7paddingyQrAE4EdgeO3SetV_12CoreGraphics7CGFloatVSgtFQOyAE4TextV_Qo__AE6VStackVyAGyAiEEAJyQrAN_ARtFQOyAC6button_6actionQrSS_yyctFQOy_Qo__Qo__AE5GroupVyAGyAZ_AZA_tGGA1_yAGyAZ_A_tGGA3_A5_A1_yAGyAZ_A2ZtGGtGGtGyXEfU_A8_yXEfU_A2_yXEfU1_yycAA7ExampleVcfu_yycfu0_ + 28
+6   iosAppSwift                     0x0000000104733590 0x010472c000 + 30096
+7   iosAppSwift                     0x000000010473353c 0x010472c000 + 30012
 8   SwiftUI                         0x0000000109acfa18 __swift_memcpy3_1 + 8096
 9   SwiftUI                         0x0000000109ad02a0 __swift_memcpy3_1 + 10280
 10  SwiftUI                         0x0000000109ad0210 __swift_memcpy3_1 + 10136
@@ -92,8 +92,8 @@ Thread 0 Crashed:
 38  SwiftUI                         0x000000010a4490d4 OUTLINED_FUNCTION_51 + 496
 39  SwiftUI                         0x000000010a448f7c OUTLINED_FUNCTION_51 + 152
 40  SwiftUI                         0x0000000109baeb60 OUTLINED_FUNCTION_10 + 88
-41  iosAppSwift                     0x000000010473d638 static iosAppSwiftApp.$main() + 40
-42  iosAppSwift                     0x000000010473e484 main + 12
+41  iosAppSwift                     0x000000010473d638 0x010472c000 + 71224
+42  iosAppSwift                     0x000000010473e484 0x010472c000 + 74884
 43  ?                               0x0000000104a79fa0 ? + 4373061536
 44  ?                               0x0000000104b5de50 ? + 4373995088
 
@@ -140,7 +140,7 @@ Thread 8:
 0   libsystem_kernel.dylib          0x00000001b05455e0 __semwait_signal + 8
 1   libsystem_c.dylib               0x0000000180127050 nanosleep + 216
 2   libsystem_c.dylib               0x0000000180126e4c sleep + 48
-3   iosAppSwift                     0x00000001047a4788 monitorCachedData + 128
+3   iosAppSwift                     0x00000001047a4788 0x010472c000 + 493448
 4   libsystem_pthread.dylib         0x00000001b059e4e4 _pthread_start + 116
 
 Thread 9 name:  KSCrash Exception Handler (Secondary)
@@ -149,7 +149,7 @@ Thread 9:
 1   libsystem_kernel.dylib          0x00000001b0553154 mach_msg2_internal + 76
 2   libsystem_kernel.dylib          0x00000001b054a4b8 mach_msg_overwrite + 536
 3   libsystem_kernel.dylib          0x00000001b054261c mach_msg + 20
-4   iosAppSwift                     0x00000001047b11b8 handleExceptions + 184
+4   iosAppSwift                     0x00000001047b11b8 0x010472c000 + 545208
 5   libsystem_pthread.dylib         0x00000001b059e4e4 _pthread_start + 116
 
 Thread 10 name:  KSCrash Exception Handler (Primary)
@@ -166,7 +166,7 @@ Thread 11:
 5   CoreFoundation                  0x000000018036d03c __CFRunLoopRun + 1152
 6   CoreFoundation                  0x000000018036c7a4 CFRunLoopRunSpecific + 584
 7   Foundation                      0x0000000180bcf02c -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 208
-8   iosAppSwift                     0x00000001047650c4 -[RollbarThread run] + 316
+8   iosAppSwift                     0x00000001047650c4 0x010472c000 + 233668
 9   Foundation                      0x0000000180bf4a10 __NSThread__start__ + 704
 10  libsystem_pthread.dylib         0x00000001b059e4e4 _pthread_start + 116
 

--- a/RollbarNotifier/Tests/RollbarCrashReportTests/RollbarCrashReportTests.swift
+++ b/RollbarNotifier/Tests/RollbarCrashReportTests/RollbarCrashReportTests.swift
@@ -25,13 +25,9 @@ final class RollbarCrashReportTests: XCTestCase {
             }
 
             XCTAssertEqual(report.crash.diagnosis, "Fatal error: Unexpectedly found nil while unwrapping an Optional value (iosAppSwift/ContentView.swift:117)")
-            XCTAssertEqual(report.crash.diagnostics.count, 3)
+            XCTAssertEqual(report.crash.diagnostics.count, 1)
             XCTAssertEqual(report.crash.diagnostics[0].source, "libswiftCore.dylib")
-            XCTAssertEqual(report.crash.diagnostics[1].source, "Exception Type")
-            XCTAssertEqual(report.crash.diagnostics[2].source, "Exception Subtype")
             XCTAssertEqual(report.crash.diagnostics[0].diagnosis, "Fatal error: Unexpectedly found nil while unwrapping an Optional value (iosAppSwift/ContentView.swift:117)")
-            XCTAssertEqual(report.crash.diagnostics[1].diagnosis, "EXC_BREAKPOINT (SIGTRAP)")
-            XCTAssertEqual(report.crash.diagnostics[2].diagnosis, "KERN_INVALID_ADDRESS at 0x000000018b87eac4")
         }
     }
 
@@ -43,7 +39,7 @@ final class RollbarCrashReportTests: XCTestCase {
 
         let expectReport = Bundle.module
             .url(forResource: "report.crash", withExtension: .none)
-            .flatMap { try? String(contentsOf: $0) }
+            .flatMap { try! String(contentsOf: $0) }
 
         XCTAssertNotNil(diagnosedCrash)
         XCTAssertNotNil(expectReport)
@@ -56,7 +52,7 @@ final class RollbarCrashReportTests: XCTestCase {
             XCTAssertNotNil(reports?.first as? String)
             XCTAssertEqual(reports?.count, 1)
 
-            guard let report = reports?.first as? String, let expectReport = expectReport else {
+            guard let report = reports?.first as? String, let expectReport else {
                 return XCTFail()
             }
 


### PR DESCRIPTION
## Description of the change

One of the Crash Reporting tests begun to fail after we stopped collecting mach diagnosis (to let the server do it), and the test wasn't updated to reflect that.

We also modified the internal symbolication so it doesn't symbolicate app frames (to let the server do it), the crash report we use to check against wasn't updated to reflect this, either.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Not being tracked

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
