### PR TITLE
Make rate limit behavior configurable for dropping or queuing

### DIFF
--- a/Demos/iosAppSwift/iosAppSwift/iosAppSwiftApp.swift
+++ b/Demos/iosAppSwift/iosAppSwift/iosAppSwiftApp.swift
@@ -31,11 +31,15 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         config.loggingOptions.codeVersion = codeVersion
 
+        // Optionally defined whether rate limited occurrences should be dropped or
+        // kept in a queue. Defaults to drop.
+        //config.loggingOptions.rateLimitBehavior = .queue
+
         // Optionally anonymize the IP address
         //config.loggingOptions.captureIp = RollbarCaptureIpType.anonymize
 
-        // Suppress (default) Rollbar internal logging
-        config.developerOptions.suppressSdkInfoLogging = true
+        // Suppress internal Rollbar logging. Defaults to true.
+        config.developerOptions.suppressSdkInfoLogging = false
 
         config.telemetry.enabled = true
         config.telemetry.captureLog = true

--- a/Demos/iosAppSwift/iosAppSwift/iosAppSwiftApp.swift
+++ b/Demos/iosAppSwift/iosAppSwift/iosAppSwiftApp.swift
@@ -33,7 +33,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         // Optionally defined whether rate limited occurrences should be dropped or
         // kept in a queue. Defaults to drop.
-        //config.loggingOptions.rateLimitBehavior = .queue
+        config.loggingOptions.rateLimitBehavior = .queue
 
         // Optionally anonymize the IP address
         //config.loggingOptions.captureIp = RollbarCaptureIpType.anonymize

--- a/RollbarCommon/Sources/RollbarCommon/DTOs/RollbarDTO.m
+++ b/RollbarCommon/Sources/RollbarCommon/DTOs/RollbarDTO.m
@@ -330,7 +330,8 @@
 
 #pragma mark - Initializers
 
-- (instancetype)initWithJSONString: (NSString *)jsonString {
+- (instancetype)initWithJSONString:(NSString *)jsonString {
+    NSAssert(jsonString && jsonString.length > 0, @"jsonString cannot be nil");
     self = [self init];
     if (self) {
         [self deserializeFromJSONString:jsonString];
@@ -338,7 +339,7 @@
     return self;
 }
 
-- (instancetype)initWithJSONData: (NSData *)data {
+- (instancetype)initWithJSONData:(NSData *)data {
     self = [self init];
     if (self) {
         [self deserializeFromJSONData:data];

--- a/RollbarNotifier/Sources/RollbarNotifier/Rollbar.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/Rollbar.m
@@ -380,15 +380,10 @@ static void uncaughtExceptionHandler(NSException * _Nonnull exception) {
 #pragma mark - Send manually constructed JSON payload
 
 + (void)sendJsonPayload:(NSData *)payload {
-
-    [[RollbarThread sharedInstance] sendPayload:payload
-                                    usingConfig:[Rollbar configuration]
-    ];
+    [[RollbarThread sharedInstance] sendPayload:payload withConfig:[Rollbar configuration]];
 }
 
-
 #pragma mark - Telemetry API
-
 
 #pragma mark - Dom
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.h
@@ -28,7 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonnull) RollbarRegistry *registry;
 
-- (BOOL)canPost;
 - (BOOL)canPostWithConfig:(nonnull RollbarConfig *)config;
 - (void)recordPostReply:(nullable RollbarPayloadPostReply *)reply
              withConfig:(nonnull RollbarConfig *)config;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.h
@@ -30,7 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)canPost;
 - (BOOL)canPostWithConfig:(nonnull RollbarConfig *)config;
-- (void)recordPostReply:(nullable RollbarPayloadPostReply *)reply;
+- (void)recordPostReply:(nullable RollbarPayloadPostReply *)reply
+             withConfig:(nonnull RollbarConfig *)config;
 
 - (instancetype)initWithConfig:(nonnull RollbarConfig *)config
                    andRegistry:(nonnull RollbarRegistry *)registry

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
@@ -1,5 +1,6 @@
 #import "RollbarDestinationRecord.h"
 #import "RollbarRegistry.h"
+#import "RollbarInfrastructure.h"
 #import "RollbarInternalLogging.h"
 
 @implementation RollbarDestinationRecord {
@@ -7,6 +8,10 @@
 }
 
 #pragma mark - property accessors
+
+- (RollbarRateLimitBehavior)rateLimitBehavior {
+    return RollbarInfrastructure.sharedInstance.configuration.loggingOptions.rateLimitBehavior;
+}
 
 #pragma mark - initializers
 
@@ -95,7 +100,7 @@
             self->_nextServerWindowStart = nil;
             return; // nothing else to do...
         case 429: // too many requests
-            if (config.loggingOptions.rateLimitBehavior == RollbarRateLimitBehavior_Queue) {
+            if (self.rateLimitBehavior == RollbarRateLimitBehavior_Queue) {
                 RBLog(@"\tQueuing record");
                 self->_nextLocalWindowStart = [NSDate dateWithTimeIntervalSinceNow:reply.remainingSeconds];
                 self->_serverWindowRemainingCount = 0;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarInfrastructure.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarInfrastructure.m
@@ -6,6 +6,7 @@
 #import "RollbarTelemetry.h"
 #import "RollbarCrashCollector.h"
 #import "RollbarInternalLogging.h"
+#import "RollbarThread.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -49,8 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self.collector install];
     [self.collector sendAllReports];
 
-    NSLog(@"Rollbar is running")
-    
+    // Create RollbarThread and begin processing persisted occurrences
+    if ([[RollbarThread sharedInstance] active]) {
+        NSLog(@"Rollbar is running")
+    }
+
     return self;
 }
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarLogger.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarLogger.m
@@ -186,38 +186,16 @@ static NSString *queuedItemsFilePath = nil;
 #pragma mark - Payload queueing/reporting
 
 - (void)report:(RollbarPayload *)payload {
-
     if (payload) {
-        
         [[RollbarThread sharedInstance] persistPayload:payload
                                             withConfig:self.configuration];
-        
-//        NSDictionary *payloadJsonData = payload.jsonFriendlyData;
-//        if (payloadJsonData) {
-//            [[RollbarThread sharedInstance] persistPayload:payloadJsonData];
-//        }
     }
 }
 
 #pragma mark - Update configuration methods
 
 - (void)updateConfiguration:(RollbarConfig *)configuration {
-
     self.configuration = [configuration copy];
 }
 
-//- (void)updateAccessToken:(NSString *)accessToken {
-//    self.configuration.destination.accessToken = accessToken;
-//}
-
-//- (void)updateReportingRate:(NSUInteger)maximumReportsPerMinute {
-//    if (nil != self.configuration) {
-//        self.configuration.loggingOptions.maximumReportsPerMinute = maximumReportsPerMinute;
-//    }
-//
-//    //[[RollbarThread sharedInstance] cancel];
-//    //[[RollbarThread sharedInstance] setReportingRate:maximumReportsPerMinute];
-//    //[[RollbarThread sharedInstance] start];
-//}
-    
 @end

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
@@ -234,7 +234,7 @@ static int selectMultipleRowsCallback(void *info, int columns, char **data, char
 }
 
 - (nullable NSDictionary<NSString *, NSString *> *)getDestinationByID:(nonnull NSString *)destinationID {
-    
+    NSAssert(destinationID && destinationID.length > 0, @"destinationID cannot be nil");
     NSString *sql = [NSString stringWithFormat:
                      @"SELECT * FROM destinations WHERE id = '%@'",
                      destinationID

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarRegistry.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarRegistry.m
@@ -17,7 +17,6 @@ const NSUInteger DEFAULT_RegistryCapacity = 10;
 }
 
 - (nonnull RollbarDestinationRecord *)getRecordForConfig:(nonnull RollbarConfig *)config {
-    
     NSAssert(config, @"Config must not be null!");
     NSAssert(config.destination, @"Destination must not be null!");
     NSAssert(config.destination.endpoint, @"destination.endpoint must not be null!");
@@ -27,18 +26,14 @@ const NSUInteger DEFAULT_RegistryCapacity = 10;
     RollbarDestinationRecord *destinationRecord = [self getRecordForEndpoint:config.destination.endpoint
                                                               andAccessToken:config.destination.accessToken];
 
-    if (destinationRecord.localWindowLimit < config.loggingOptions.maximumReportsPerMinute) {
-        
-        // we use lagest configured limit per destination:
-        destinationRecord.localWindowLimit = config.loggingOptions.maximumReportsPerMinute;
-    }
-    
+    destinationRecord.localWindowLimit = MAX(destinationRecord.localWindowLimit, config.loggingOptions.maximumReportsPerMinute);
+
     return destinationRecord;
 }
 
 - (nonnull RollbarDestinationRecord *)getRecordForEndpoint:(nonnull NSString *)endpoint
-                                            andAccessToken:(nonnull NSString *)accessToken {
-
+                                            andAccessToken:(nonnull NSString *)accessToken \
+{
     NSAssert(endpoint, @"endpoint must not be null!");
     NSAssert(accessToken, @"accessToken must not be null!");
 
@@ -46,23 +41,12 @@ const NSUInteger DEFAULT_RegistryCapacity = 10;
     RollbarDestinationRecord *destinationRecord = self->_destinationRecords[destinationID];
     if (!destinationRecord) {
         destinationRecord = [[RollbarDestinationRecord alloc] initWithDestinationID:destinationID
-                                                                        andRegistry:self
-        ];
+                                                                        andRegistry:self];
         self->_destinationRecords[destinationID] = destinationRecord;
     }
-    
-//    if (destinationRecord.localWindowLimit < config.loggingOptions.maximumReportsPerMinute) {
-//
-//        // we use lagest configured limit per destination:
-//        destinationRecord.localWindowLimit = config.loggingOptions.maximumReportsPerMinute;
-//    }
-    
+
     return destinationRecord;
 }
-
-
-
-
 
 - (NSUInteger)totalDestinationRecords {
     return self->_destinationRecords.count;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarSender.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarSender.m
@@ -90,6 +90,7 @@
         session = [NSURLSession sessionWithConfiguration:sessionConfig];
     }
 
+    RBLog(@"\tSending payload...");
     NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
                                                 completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         httpResponse = [self checkPayloadResponse:response error:error];
@@ -107,11 +108,11 @@
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
 
     if (httpResponse.statusCode == 200) {
-        RBLog(@"OK response from Rollar");
+        RBLog(@"\tOK response from Rollbar");
     } else {
-        RBLog(@"There was a problem reporting to Rollbar:");
-        RBLog(@"\tError: %@", [error localizedDescription]);
-        RBLog(@"\tResponse: %@", httpResponse);
+        RBLog(@"\tThere was a problem reporting to Rollbar:");
+        RBLog(@"\t\tError: %@", [error localizedDescription]);
+        RBLog(@"\t\tResponse: %d", httpResponse.statusCode);
     }
 
     return httpResponse;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.h
@@ -17,19 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (RollbarTriStateFlag)sendPayload:(nonnull NSData *)payload
                         withConfig:(nonnull RollbarConfig *)config;
 
-/// Hides the initializer.
 - (instancetype)init NS_UNAVAILABLE;
-
-/// Hides the initializer.
-- (instancetype)initWithTarget:(id)target
-                      selector:(SEL)selector
-                        object:(nullable id)argument
-NS_UNAVAILABLE;
-
+- (instancetype)initWithTarget:(id)target selector:(SEL)selector object:(nullable id)argument NS_UNAVAILABLE;
 - (instancetype)initWithBlock:(void (^)(void))block NS_UNAVAILABLE;
 
-
-#pragma mark - Sigleton pattern
+#pragma mark - Singleton pattern
 
 + (nonnull instancetype)sharedInstance;
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.h
@@ -2,6 +2,7 @@
 
 #import "RollbarConfig.h"
 #import "RollbarPayload.h"
+#import "RollbarDestinationRecord.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,13 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Signifies that the thread is active or not.
 @property(atomic) BOOL active;
 
-//- (void)persist:(nonnull RollbarPayload *)payload;
-
 - (void)persistPayload:(nonnull RollbarPayload *)payload
             withConfig:(nonnull RollbarConfig *)config;
 
 - (RollbarTriStateFlag)sendPayload:(nonnull NSData *)payload
-                       usingConfig:(nonnull RollbarConfig  *)config;
+                        withConfig:(nonnull RollbarConfig *)config;
 
 /// Hides the initializer.
 - (instancetype)init NS_UNAVAILABLE;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.m
@@ -577,7 +577,7 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
     }
     
     RollbarPayloadPostReply *reply = [[RollbarSender new] sendPayload:payload usingConfig:config];
-    [record recordPostReply:reply];
+    [record recordPostReply:reply withConfig:config];
     
     if (!reply) {
         return RollbarTriStateFlag_None; // nothing obviously wrong with the payload - just there was no deterministic

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.m
@@ -106,11 +106,11 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
         NSTimeInterval timeIntervalInSeconds = 60.0 / _maxReportsPerMinute;
         
         _timer = [NSTimer timerWithTimeInterval:timeIntervalInSeconds
-                                        target:self
-                                      selector:@selector(checkItems)
-                                      userInfo:nil
-                                       repeats:YES
-                 ];
+                                         target:self
+                                       selector:@selector(checkItems)
+                                       userInfo:nil
+                                        repeats:YES
+        ];
         
         NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
         [runLoop addTimer:_timer forMode:NSDefaultRunLoopMode];
@@ -159,7 +159,7 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
                                 withConfig:(nonnull RollbarConfig *)config {
     
     if (config.modifyRollbarData) {
-    
+
         @try {
             payload.data = config.modifyRollbarData(payload.data);
         }
@@ -229,7 +229,7 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
 }
 
 + (void)createMutableDataWithData:(NSMutableDictionary *)data
-                           forPath:(NSString *)path {
+                          forPath:(NSString *)path {
     
     NSArray *pathComponents = [path componentsSeparatedByString:@"."];
     NSString *currentPath = @"";
@@ -295,8 +295,6 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
 }
 
 - (void)savePayload:(nonnull RollbarPayload *)payload withConfig:(nonnull RollbarConfig *)config {
-    RBLog(@"RollbarThread::savePayload: %@", payload.data.body);
-
     if ([RollbarThread shouldIgnorePayload:payload withConfig:config]) {
         
         if (config.developerOptions.logIncomingPayloads) {
@@ -376,8 +374,8 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
         RBErr(@"invalid configJson!");
         return;
     }
-    
-    //[payload.data.notifier setData:config.jsonFriendlyData byKey:@"configured_options"];
+
+    RBLog(@"Queuing %@ (%d in queue)", payload.data.uuid, [self->_payloadsRepo getPayloadCount]);
     NSString *payloadJson = [payload serializeToJSONString];
     NSDictionary *payloadDataRow = [self->_payloadsRepo addPayload:payloadJson
                                                         withConfig:configJson
@@ -421,8 +419,8 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
         ) {
         // we either have some sort of timestamp corruption or
         // we are processing a stale payload let's just drop it and call it done:
-        [self->_payloadsRepo removePayloadByID:payloadDataRow[@"id"]];
-        
+        [self removePayloadByID:payloadDataRow[@"id"]];
+
         RollbarConfig *config = [[RollbarConfig alloc] initWithJSONString:payloadDataRow[@"config_json"]];
         
         if (config && config.developerOptions.logTransmittedPayloads) {
@@ -444,65 +442,45 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
 }
 
 - (void)processSavedPayload:(nonnull NSDictionary<NSString *, NSString *> *)payloadDataRow {
-    
     if ([self checkProcessStalePayload:payloadDataRow]) {
         return;
     }
 
-    NSString *destinationKey = payloadDataRow[@"destination_key"];
-    NSAssert(destinationKey && destinationKey.length > 0, @"destination_key is expected to be defined!");
-    NSDictionary<NSString *, NSString *> *destination = [self->_payloadsRepo getDestinationByID:destinationKey];
-    
-    //TODO: remove this code-block before the upcoming major release:
-    if (!destination) {
-        RBLog(@"Aha!");
-        [self->_payloadsRepo removePayloadByID:payloadDataRow[@"id"]];
-        return;
-    }
-    
-    NSAssert(destination, @"destination can not be nil!");
-    NSAssert(destination[@"endpoint"], @"destination endpoint can not be nil!");
-    NSAssert(destination[@"access_token"], @"destination access_token can not be nil!");
+    NSDictionary<NSString *, NSString *> *destination = [self->_payloadsRepo getDestinationByID:payloadDataRow[@"destination_key"]];
     RollbarDestinationRecord *destinationRecord = [self->_registry getRecordForEndpoint:destination[@"endpoint"]
                                                                          andAccessToken:destination[@"access_token"]];
-    NSString *configJson = payloadDataRow[@"config_json"];
-    NSAssert(configJson && configJson.length > 0, @"config_json is expected to be defined!");
-    RollbarConfig *config = [[RollbarConfig alloc] initWithJSONString:configJson];
-    NSAssert(config, @"config is expected to be defined!");
-    
+    RollbarConfig *config = [[RollbarConfig alloc] initWithJSONString:payloadDataRow[@"config_json"]];
+    RollbarPayload *payload = [[RollbarPayload alloc] initWithJSONString:payloadDataRow[@"payload_json"]];
+
     if (![destinationRecord canPostWithConfig:config]) {
+        if (config.loggingOptions.rateLimitBehavior == RollbarRateLimitBehavior_Drop) {
+            RBLog(@"Processing %@ (%d in queue)", payload.data.uuid, [self->_payloadsRepo getPayloadCount]);
+            RBLog(@"\tRate limited");
+            [self removePayloadByID:payloadDataRow[@"id"]];
+            RBLog(@"Dropped %@", payload.data.uuid);
+        }
         return;
     }
-    
-    NSString *payloadJson = payloadDataRow[@"payload_json"];
-    RollbarPayload *payload = [[RollbarPayload alloc] initWithJSONString:payloadJson];
-    NSAssert(payload, @"payload is expected to be defined!");
-        
+
+    RBLog(@"Processing %@ (%d in queue)", payload.data.uuid, [self->_payloadsRepo getPayloadCount]);
+
     NSError *error;
     NSData *jsonPayload = [NSJSONSerialization rollbar_dataWithJSONObject:payload.jsonFriendlyData
                                                                   options:0
                                                                     error:&error
                                                                      safe:true];
-    if (nil == jsonPayload) {
+    if (jsonPayload == nil) {
         RBErr(@"Couldn't send jsonPayload that is nil");
-        if (nil != error) {
-            RBErr(@"   DETAILS: an error while generating JSON data: %@", error);
+        if (error != nil) {
+            RBErr(@"\tError while generating JSON data: %@", error);
         }
-        // there is nothing we can do with this payload - let's drop it:
-        RBErr(@"Dropping unprocessable payload: %@", payloadJson);
-        if (![self->_payloadsRepo removePayloadByID:payloadDataRow[@"id"]]) {
-            RBErr(@"Couldn't remove payload data row with ID: %@", payloadDataRow[@"id"]);
-        }
+        [self removePayloadByID:payloadDataRow[@"id"]];
         return;
     }
 
-    RBLog(@"Processing %d payloads left", [self->_payloadsRepo getPayloadCount]);
-    
     RollbarTriStateFlag result = RollbarTriStateFlag_On;
-    if (!config) {
-        result = [self sendPayload:jsonPayload]; // backward compatibility with just upgraded very old SDKs...
-    } else if (config.developerOptions.transmit) {
-        result = [self sendPayload:jsonPayload usingConfig:config];
+    if (config.developerOptions.transmit) {
+        result = [self sendPayload:jsonPayload toDestination:destinationRecord withConfig:config];
     }
     
     NSString *payloadsLogFile = nil;
@@ -510,20 +488,14 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
     switch (result) {
         case RollbarTriStateFlag_On:
             // The payload is fully processed and transmitted.
-            // It can be removed from the repo:
-            if (![self->_payloadsRepo removePayloadByID:payloadDataRow[@"id"]]) {
-                RBErr(@"Couldn't remove payload data row with ID: %@", payloadDataRow[@"id"]);
-            }
+            [self removePayloadByID:payloadDataRow[@"id"]];
             if (config.developerOptions.logTransmittedPayloads) {
                 payloadsLogFile = config.developerOptions.transmittedPayloadsLogFile;
             }
             break;
         case RollbarTriStateFlag_Off:
             // The payload is fully processed but not accepted by the server due to some invalid content.
-            // It must be removed from the repo:
-            if (![self->_payloadsRepo removePayloadByID:payloadDataRow[@"id"]]) {
-                RBErr(@"Couldn't remove payload data row with ID: %@", payloadDataRow[@"id"]);
-            }
+            [self removePayloadByID:payloadDataRow[@"id"]];
             if (config.developerOptions.logDroppedPayloads) {
                 payloadsLogFile = config.developerOptions.droppedPayloadsLogFile;
             }
@@ -541,11 +513,10 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
         [RollbarFileWriter appendSafelyData:jsonPayload toFile:payloadsLogFilePath];
     }
 
-    RBLog([self loggableStringFromPayload:jsonPayload result:result]);
+    RBLog([self loggableStringFromPayload:payload result:result]);
 }
 
 - (void)processSavedItems {
-    
 #if !TARGET_OS_WATCH
     if (!self->_isNetworkReachable) {
         RBLog(@"Processing saved items: no network!");
@@ -565,17 +536,23 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
 }
 
 - (RollbarTriStateFlag)sendPayload:(nonnull NSData *)payload
-                       usingConfig:(nonnull RollbarConfig *)config
+                        withConfig:(nonnull RollbarConfig *)config
+{
+    RollbarDestinationRecord *destination = [self->_registry getRecordForConfig:config];
+    if ([destination canPostWithConfig:config]) {
+        return [self sendPayload:payload toDestination:destination withConfig:config];
+    }
+    return RollbarTriStateFlag_None; // nothing obviously wrong with the payload - just can not send at the moment
+}
+
+- (RollbarTriStateFlag)sendPayload:(nonnull NSData *)payload
+                     toDestination:(nullable RollbarDestinationRecord *)record
+                        withConfig:(nonnull RollbarConfig *)config
 {
     if (!payload || !config) {
         return RollbarTriStateFlag_Off; //obviously invalid payload to sent or invalid destination...
     }
-    
-    RollbarDestinationRecord *record = [self->_registry getRecordForConfig:config];
-    if (![record canPost]) {
-        return RollbarTriStateFlag_None; // nothing obviously wrong with the payload - just can not send at the moment
-    }
-    
+
     RollbarPayloadPostReply *reply = [[RollbarSender new] sendPayload:payload usingConfig:config];
     [record recordPostReply:reply withConfig:config];
     
@@ -584,26 +561,26 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
                                          // reply from the destination server
     }
     
-    switch(reply.statusCode) {
+    switch (reply.statusCode) {
         case 200: // OK
             return RollbarTriStateFlag_On; // the payload was successfully transmitted
         case 400: // bad request
         case 413: // request entity too large
         case 422: // unprocessable entity
             return RollbarTriStateFlag_Off; // unecceptable request/payload - should be dropped
+        case 429: // too many requests
+            switch (config.loggingOptions.rateLimitBehavior) {
+                case RollbarRateLimitBehavior_Queue:
+                    return RollbarTriStateFlag_None;
+                case RollbarRateLimitBehavior_Drop:
+                default:
+                    return RollbarTriStateFlag_Off;
+            }
         case 403: // access denied
         case 404: // not found
-        case 429: // too many requests
         default:
             return RollbarTriStateFlag_None; // worth retrying later
     }
-}
-
-/// This is a DEPRECATED method left for some backward compatibility for very old clients eventually moving to this more recent implementation.
-/// Use/maintain sendPayload:usingConfig: instead!
-- (RollbarTriStateFlag)sendPayload:(NSData *)payload {
-    
-    return RollbarTriStateFlag_Off;
 }
 
 #pragma mark - Network telemetry data
@@ -638,16 +615,20 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
 
 #pragma mark -
 
-- (NSString *)loggableStringFromPayload:(NSData *)jsonPayload result:(RollbarTriStateFlag)result {
-    NSString *payloadString = [[NSString alloc] initWithData:jsonPayload encoding:NSUTF8StringEncoding];
-    NSString *truncatedPayload = [payloadString substringToIndex:MIN(payloadString.length, 128)];
+- (void)removePayloadByID:(nonnull NSString *)payloadID {
+    if (![self->_payloadsRepo removePayloadByID:payloadID]) {
+        RBErr(@"\tCouldn't remove payload data row with ID: %@", payloadID);
+    } else {
+        RBLog(@"\tRecord dropped");
+    }
+}
 
+- (NSString *)loggableStringFromPayload:(RollbarPayload *)payload result:(RollbarTriStateFlag)result {
     NSString *resultString =
         result == RollbarTriStateFlag_On ? @"Transmitted" :
-        result == RollbarTriStateFlag_Off ? @"Dropped" :
-        @"Unavailable will retry";
+        result == RollbarTriStateFlag_Off ? @"Dropped" : @"Queued";
 
-    return [NSString stringWithFormat:@"%@ payload: %@", resultString, truncatedPayload];
+    return [NSString stringWithFormat:@"%@ %@", resultString, payload.data.uuid];
 }
 
 #pragma mark - Singleton pattern

--- a/RollbarNotifier/Sources/RollbarNotifier/include/RollbarLoggingOptions.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/include/RollbarLoggingOptions.h
@@ -7,6 +7,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, RollbarRateLimitBehavior) {
+    RollbarRateLimitBehavior_Drop,
+    RollbarRateLimitBehavior_Queue
+};
+
 /// Models logging settings of a configuration
 @interface RollbarLoggingOptions : RollbarDTO
 
@@ -20,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Reporting rate limit
 @property (nonatomic, readonly) NSUInteger maximumReportsPerMinute;
+
+/// Whether to drop or queue rate limited occurrences, defaults to drop.
+@property (nonatomic, readonly) RollbarRateLimitBehavior rateLimitBehavior;
 
 /// A way of capturing IP addresses
 @property (nonatomic, readonly) RollbarCaptureIpType captureIp;
@@ -39,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param logLevel minimum log level to start logging from
 /// @param crashLevel log level to mark crash reports with
 /// @param maximumReportsPerMinute Reporting rate limit
+/// @param rateLimitBehavior Whether to drop or queue rate limited occurrences
 /// @param captureIp a way of capturing IP addresses
 /// @param codeVersion a code version to mark payloads with
 /// @param framework A framework tag to mark payloads with
@@ -46,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithLogLevel:(RollbarLevel)logLevel
                       crashLevel:(RollbarLevel)crashLevel
          maximumReportsPerMinute:(NSUInteger)maximumReportsPerMinute
+               rateLimitBehavior:(RollbarRateLimitBehavior)rateLimitBehavior
                        captureIp:(RollbarCaptureIpType)captureIp
                      codeVersion:(nullable NSString *)codeVersion
                        framework:(nullable NSString *)framework
@@ -55,12 +65,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param logLevel minimum log level to start logging from
 /// @param crashLevel log level to mark crash reports with
 /// @param maximumReportsPerMinute Reporting rate limit
+/// @param rateLimitBehavior Whether to drop or queue rate limited occurrences
 /// @param codeVersion a code version to mark payloads with
 /// @param framework A framework tag to mark payloads with
 /// @param requestId A request ID to mark payloads with
 - (instancetype)initWithLogLevel:(RollbarLevel)logLevel
                       crashLevel:(RollbarLevel)crashLevel
          maximumReportsPerMinute:(NSUInteger)maximumReportsPerMinute
+               rateLimitBehavior:(RollbarRateLimitBehavior)rateLimitBehavior
                      codeVersion:(nullable NSString *)codeVersion
                        framework:(nullable NSString *)framework
                        requestId:(nullable NSString *)requestId;
@@ -95,9 +107,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param logLevel minimum log level to start logging from
 /// @param crashLevel log level to mark crash reports with
 /// @param maximumReportsPerMinute Reporting rate limit
+/// @param rateLimitBehavior Whether to drop or queue rate limited occurrences
 - (instancetype)initWithLogLevel:(RollbarLevel)logLevel
                       crashLevel:(RollbarLevel)crashLevel
-         maximumReportsPerMinute:(NSUInteger)maximumReportsPerMinute;
+         maximumReportsPerMinute:(NSUInteger)maximumReportsPerMinute
+               rateLimitBehavior:(RollbarRateLimitBehavior)rateLimitBehavior;
 
 /// Initializer
 /// @param logLevel minimum log level to start logging from
@@ -124,6 +138,9 @@ NS_DESIGNATED_INITIALIZER;
 
 /// Reporting rate limit
 @property (nonatomic, readwrite) NSUInteger maximumReportsPerMinute;
+
+/// Whether to drop or queue rate limited occurrences, defaults to drop.
+@property (nonatomic, readwrite) RollbarRateLimitBehavior rateLimitBehavior;
 
 /// A way of capturing IP addresses
 @property (nonatomic, readwrite) RollbarCaptureIpType captureIp;

--- a/RollbarNotifier/Tests/RollbarNotifierTests-ObjC/DTOsTests.m
+++ b/RollbarNotifier/Tests/RollbarNotifierTests-ObjC/DTOsTests.m
@@ -282,7 +282,8 @@
 - (void)testRollbarLoggingOptionsDTO {
     RollbarMutableLoggingOptions *dto = [[RollbarMutableLoggingOptions alloc] initWithLogLevel:RollbarLevel_Error
                                                                                     crashLevel:RollbarLevel_Info
-                                                                       maximumReportsPerMinute:45];
+                                                                       maximumReportsPerMinute:45
+                                                                             rateLimitBehavior:RollbarRateLimitBehavior_Queue];
     dto.captureIp = RollbarCaptureIpType_Anonymize;
     dto.codeVersion = @"CODEVERSION";
     dto.framework = @"FRAMEWORK";

--- a/RollbarNotifier/Tests/RollbarNotifierTests-ObjC/RollbarRegistryTests.m
+++ b/RollbarNotifier/Tests/RollbarNotifierTests-ObjC/RollbarRegistryTests.m
@@ -40,22 +40,22 @@
     
     RollbarDestinationRecord *record = [registry getRecordForConfig:config];
     XCTAssertEqual(1, registry.totalDestinationRecords);
-    XCTAssertEqual(YES, [record canPost]);
+    XCTAssertEqual(YES, [record canPostWithConfig:config]);
     XCTAssertNotNil(record.nextEarliestPost);
     XCTAssertNil(record.nextLocalWindowStart);
     XCTAssertNil(record.nextServerWindowStart);
 
     RollbarPayloadPostReply *reply = [RollbarPayloadPostReply greenReply];
-    [record recordPostReply:reply];
-    XCTAssertTrue([record canPost]);
+    [record recordPostReply:reply withConfig:config];
+    XCTAssertTrue([record canPostWithConfig:config]);
     
     reply = [RollbarPayloadPostReply yellowReply];
-    [record recordPostReply:reply];
-    XCTAssertFalse([record canPost]);
+    [record recordPostReply:reply withConfig:config];
+    XCTAssertFalse([record canPostWithConfig:config]);
 
     reply = [RollbarPayloadPostReply redReply];
-    [record recordPostReply:reply];
-    XCTAssertFalse([record canPost]);
+    [record recordPostReply:reply withConfig:config];
+    XCTAssertFalse([record canPostWithConfig:config]);
 }
 
 #pragma mark - registry records tests

--- a/RollbarNotifier/Tests/RollbarNotifierTests/RollbarNotifierDTOsTests.swift
+++ b/RollbarNotifier/Tests/RollbarNotifierTests/RollbarNotifierDTOsTests.swift
@@ -292,7 +292,8 @@ final class RollbarNotifierDTOsTests: XCTestCase {
         var dto = RollbarMutableLoggingOptions(
             logLevel: .error,
             crash: .info,
-            maximumReportsPerMinute: UInt(45)
+            maximumReportsPerMinute: UInt(45),
+            rateLimitBehavior: .queue
         );
         dto.captureIp = .anonymize;
         dto.codeVersion = "CODEVERSION";


### PR DESCRIPTION
## Description of the change

This is the final PR for [122305](https://app.shortcut.com/rollbar/story/122305/rate-limiting-isn-t-handled-correctly-which-results-into-more-requests-to-be-sent) following https://github.com/rollbar/rollbar-apple/pull/276.

This PR introduces the ability to configure some behavior when dealing with rate limiting. Users can now specify whether they'd like to drop occurrences (and their API requests) that fall under rate limit, or keep them in the queue to be sent in the next window of time.

_The default behavior is to **drop** the rate limited occurrence._

If there are persisted occurrences at the moment the application starts, and behavior is configured to drop occurrences, all the persisted occurrences will be removed _iff_ the first attempt at sending a persisted occurrence is rate limited.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fixes [122305](https://app.shortcut.com/rollbar/story/122305/rate-limiting-isn-t-handled-correctly-which-results-into-more-requests-to-be-sent)
- Fixes https://github.com/rollbar/rollbar-apple/issues/255.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
