### PR TITLE
Podspec updates and code changes friendlier to Cocoapods

### DIFF
--- a/Demos/iosAppSwift/iosAppSwift.xcodeproj/project.pbxproj
+++ b/Demos/iosAppSwift/iosAppSwift.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 61;
 				DEVELOPMENT_ASSET_PATHS = "\"iosAppSwift/Preview Content\"";
 				DEVELOPMENT_TEAM = 9P5JVC2F34;
 				ENABLE_PREVIEWS = YES;
@@ -302,7 +302,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.apple.demo.swift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -317,7 +317,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 61;
 				DEVELOPMENT_ASSET_PATHS = "\"iosAppSwift/Preview Content\"";
 				DEVELOPMENT_TEAM = 9P5JVC2F34;
 				ENABLE_PREVIEWS = YES;
@@ -335,7 +335,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.apple.demo.swift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "cocoalumberjack",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
+      "state" : {
+        "revision" : "0188d31089b5881a269e01777be74c7316924346",
+        "version" : "3.8.0"
+      }
+    },
+    {
+      "identity" : "kscrash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kstenerud/KSCrash.git",
+      "state" : {
+        "revision" : "c49092e96815ea6cb348862cd2a8c03bb8bd63f2",
+        "version" : "1.15.26"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -1,0 +1,75 @@
+Pod::Spec.new do |s|
+  s.name         = "Rollbar"
+  s.version      = "3.0.0"
+  s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
+  s.description  = <<-DESC
+                    Find, fix, and resolve errors with Rollbar.
+                    Easily send error data using Rollbar API.
+                    Analyze, de-dupe, send alerts, and prepare the data for further analysis.
+                    Search, sort, and prioritize via the Rollbar dashboard.
+                  DESC
+
+  s.homepage     = "https://rollbar.com"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.authors      = { "Rollbar" => "support@rollbar.com" }
+  s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
+                     :tag => s.version.to_s }
+
+  s.documentation_url = "https://docs.rollbar.com/docs/apple"
+  s.social_media_url  = "http://twitter.com/rollbar"
+  s.resource = "rollbar-logo.png"
+
+  s.osx.deployment_target = "12.0"
+  s.ios.deployment_target = "14.0"
+  s.tvos.deployment_target = "14.0"
+  s.watchos.deployment_target = "8.0"
+
+  s.module_name  = "RollbarNotifier"
+  s.requires_arc = true
+  s.frameworks = 'Foundation'
+  s.swift_versions = "5.5"
+
+  s.pod_target_xcconfig = {
+      'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
+      'CLANG_CXX_LIBRARY' => 'libc++'
+  }
+  s.watchos.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -framework WatchKit'
+  }
+
+  s.source_files  = "RollbarNotifier/Sources/RollbarNotifier/**/*.{h,m}", "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
+  s.public_header_files = "RollbarNotifier/Sources/RollbarNotifier/include/*.h"
+  s.module_map = "RollbarNotifier/Sources/RollbarNotifier/include/module.modulemap"
+
+  s.default_subspecs = ['Common']
+
+  s.dependency "KSCrash", "~> 1.15.27"
+
+  s.subspec 'Common' do |sp|
+      sp.source_files  = "RollbarCommon/Sources/RollbarCommon/**/*.{h,m}"
+      sp.public_header_files = "RollbarCommon/Sources/RollbarCommon/include/*.h"
+      #sp.module_map = "RollbarCommon/Sources/RollbarCommon/include/module.modulemap"
+  end
+
+  s.subspec 'AUL' do |sp|
+      sp.source_files = "RollbarAUL/Sources/RollbarAUL/**/*.{h,m}"
+      sp.public_header_files = "RollbarAUL/Sources/RollbarAUL/include/*.h"
+      #sp.module_map = "RollbarAUL/Sources/RollbarAUL/include/module.modulemap"
+  end
+
+  s.subspec 'CocoaLumberjack' do |sp|
+      sp.source_files  = "RollbarCocoaLumberjack/Sources/RollbarCocoaLumberjack/**/*.{h,m}"
+      sp.public_header_files = "RollbarCocoaLumberjack/Sources/RollbarCocoaLumberjack/include/*.h"
+      #sp.module_map = "RollbarCocoaLumberjack/Sources/RollbarCocoaLumberjack/include/module.modulemap"
+
+      #sp.static_framework = true
+      sp.dependency "CocoaLumberjack", "~> 3.7.4"
+  end
+
+  s.subspec 'Deploys' do |sp|
+      sp.source_files  = "RollbarDeploys/Sources/RollbarDeploys/**/*.{h,m}"
+      sp.public_header_files = "RollbarDeploys/Sources/RollbarDeploys/include/*.h"
+      #sp.module_map = "RollbarDeploys/Sources/RollbarDeploys/include/module.modulemap"
+  end
+end

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name         = "RollbarCrashReport"
+  s.version      = "3.0.0"
+  s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
+  s.description  = <<-DESC
+                    Find, fix, and resolve errors with Rollbar.
+                    Easily send error data using Rollbar API.
+                    Analyze, de-dupe, send alerts, and prepare the data for further analysis.
+                    Search, sort, and prioritize via the Rollbar dashboard.
+                 DESC
+
+  s.homepage     = "https://rollbar.com"
+  s.resource     = "rollbar-logo.png"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.authors      = { "Rollbar" => "support@rollbar.com" }
+  s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
+                     :tag => s.version.to_s }
+  s.documentation_url = "https://docs.rollbar.com/docs/apple"
+  s.social_media_url  = "http://twitter.com/rollbar"
+
+  s.osx.deployment_target = "12.0"
+  s.ios.deployment_target = "14.0"
+  s.tvos.deployment_target = "14.0"
+  s.watchos.deployment_target = "8.0"
+
+  s.module_name = "RollbarCrashReport"
+  s.dependency "KSCrash", "~> 1.15"
+  s.frameworks = "Foundation"
+  s.source_files  = "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
+end

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
 
     s.framework = "Foundation"
     s.dependency "RollbarCommon", "~> #{s.version}"
+    s.dependency "KSCrash", "~> 1.15.27"
 
     s.requires_arc = true
 end

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                       :tag => "#{s.version}" }
+                       :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.social_media_url  = "http://twitter.com/rollbar"
 
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = "14.0"
     s.watchos.deployment_target = "8.0"
 
-    s.source_files  = "#{s.name}/Sources/#{s.name}/**/*.{h,m}"
+    s.source_files  = "#{s.name}/Sources/#{s.name}/**/*.{h,m}", "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
     s.public_header_files = "#{s.name}/Sources/#{s.name}/include/*.h"
     s.module_map = "#{s.name}/Sources/#{s.name}/include/module.modulemap"
 

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-    s.version      = "3.0.0"
     s.name         = "RollbarNotifier"
+    s.version      = "3.0.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -8,14 +8,15 @@ Pod::Spec.new do |s|
                       Analyze, de-dupe, send alerts, and prepare the data for further analysis.
                       Search, sort, and prioritize via the Rollbar dashboard.
                    DESC
+
     s.homepage     = "https://rollbar.com"
+    s.resource     = "rollbar-logo.png"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
                        :tag => "#{s.version}" }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.social_media_url  = "http://twitter.com/rollbar"
-    s.resource = "rollbar-logo.png"
 
     s.osx.deployment_target = "12.0"
     s.ios.deployment_target = "14.0"

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -23,13 +23,14 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = "14.0"
     s.watchos.deployment_target = "8.0"
 
-    s.source_files  = "#{s.name}/Sources/#{s.name}/**/*.{h,m}", "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
+    s.source_files  = "#{s.name}/Sources/#{s.name}/**/*.{h,m}"
     s.public_header_files = "#{s.name}/Sources/#{s.name}/include/*.h"
     s.module_map = "#{s.name}/Sources/#{s.name}/include/module.modulemap"
 
     s.framework = "Foundation"
     s.dependency "RollbarCommon", "~> #{s.version}"
-    s.dependency "KSCrash", "~> 1.15.27"
+    s.dependency "RollbarCrashReport", "~> #{s.version}"
+    s.dependency "KSCrash", "~> 1.15"
 
     s.requires_arc = true
 end

--- a/RollbarNotifier/Sources/RollbarCrashReport/Diagnostic/RollbarCrashDiagnosticFilter.swift
+++ b/RollbarNotifier/Sources/RollbarCrashReport/Diagnostic/RollbarCrashDiagnosticFilter.swift
@@ -1,4 +1,8 @@
+#if canImport(KSCrash_Reporting_Filters)
 import KSCrash_Reporting_Filters
+#else
+import KSCrash
+#endif
 
 /// A `KSCrash` filter that produces richer diagnostic information by extracting data from a raw
 /// crash hashmap that's not usually made available in Apple crash reports.

--- a/RollbarNotifier/Sources/RollbarCrashReport/Formatter/RollbarCrashFormattingFilter.swift
+++ b/RollbarNotifier/Sources/RollbarCrashReport/Formatter/RollbarCrashFormattingFilter.swift
@@ -1,5 +1,8 @@
-import Foundation
+#if canImport(KSCrash_Reporting_Filters)
 import KSCrash_Reporting_Filters
+#else
+import KSCrash
+#endif
 
 /// A `KSCrash` filter that produces a proper Apple crash report with rich diagnostic
 /// information by parsing data from a raw crash hashmap.

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.h
@@ -1,9 +1,10 @@
 #ifndef RollbarCrashCollector_h
 #define RollbarCrashCollector_h
 
+#import "KSCrashInstallation.h"
+
 @import Foundation;
 @import RollbarCommon;
-@import KSCrash_Installations;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
@@ -38,13 +38,13 @@ static bool isDebuggerAttached();
     [super install];
 
     KSCrashMonitorType monitoring = isDebuggerAttached()
-    ? KSCrashMonitorTypeDebuggerSafe
-    & ~(KSCrashMonitorTypeOptional
-        | KSCrashMonitorTypeExperimental
-        | KSCrashMonitorTypeUserReported)
-    : KSCrashMonitorTypeProductionSafe
-    & ~(KSCrashMonitorTypeOptional
-        | KSCrashMonitorTypeUserReported);
+        ? KSCrashMonitorTypeDebuggerSafe
+        & ~(KSCrashMonitorTypeOptional
+            | KSCrashMonitorTypeExperimental
+            | KSCrashMonitorTypeUserReported)
+        : KSCrashMonitorTypeProductionSafe
+        & ~(KSCrashMonitorTypeOptional
+            | KSCrashMonitorTypeUserReported);
 
     [KSCrash.sharedInstance setDeleteBehaviorAfterSendAll:KSCDeleteOnSucess];
     [KSCrash.sharedInstance setDemangleLanguages:KSCrashDemangleLanguageAll];

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
@@ -1,8 +1,8 @@
 #import "Rollbar.h"
 #import "RollbarCrashCollector.h"
 #import "RollbarInternalLogging.h"
+#import "KSCrashReportFilter.h"
 
-@import KSCrash_Reporting_Sinks;
 @import RollbarCrashReport;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
@@ -33,6 +33,7 @@
         self->_nextServerWindowStart = nil;
         self->_nextEarliestPost = [NSDate date];
     }
+    return self;
 }
 
 - (instancetype)initWithDestinationID:(nonnull NSString *)destinationID

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarLogger+Test.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarLogger+Test.m
@@ -25,17 +25,17 @@
 
 + (nonnull NSArray<NSMutableDictionary *> *)readPayloadsFromSdkIncomingLog {
     
-    [RollbarLogger readPayloadsDataFromFile:[RollbarLogger _incomingPayloadsLogPath]];
+    return [RollbarLogger readPayloadsDataFromFile:[RollbarLogger _incomingPayloadsLogPath]];
 }
 
 + (nonnull NSArray<NSMutableDictionary *> *)readPayloadsFromSdkTransmittedLog {
     
-    [RollbarLogger readPayloadsDataFromFile:[RollbarLogger _transmittedPayloadsLogPath]];
+    return [RollbarLogger readPayloadsDataFromFile:[RollbarLogger _transmittedPayloadsLogPath]];
 }
 
 + (nonnull NSArray<NSMutableDictionary *> *)readPayloadsFromSdkDroppedLog {
     
-    [RollbarLogger readPayloadsDataFromFile:[RollbarLogger _droppedPayloadsLogPath]];
+    return [RollbarLogger readPayloadsDataFromFile:[RollbarLogger _droppedPayloadsLogPath]];
 }
 
 + (nonnull NSArray<NSMutableDictionary *> *)readPayloadsDataFromFile:(nonnull NSString *)filePath {


### PR DESCRIPTION
## Description of the change

Since the last update of Xcode 14.3, support for iOS versions under 11.0 was dropped. This means that certain libraries aren't available to be linked when the minimum deployment version is set under 11.0.

This means that certain libraries whose `podspec` files are configured for a deployment target under 11.0 won't compile when using Cocoapods.

What makes matters worse is that there doesn't seem to be intent to fix this issue quickly: https://github.com/CocoaPods/CocoaPods/issues/11895#issuecomment-1545797496 since Cocoapods has been poorly maintained for quite a while.

This is the first set of changes that attempts to find a way around this problem.

This only affects Cocoapods, SPM and Carthage continue to work fine.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- https://app.shortcut.com/rollbar/story/126159/fix-cocoapods-support

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
