### PR TITLE
Pod for RollbarCrashReport module and other cocoapods fixes

### DIFF
--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
                      :tag => s.version.to_s }
 
   s.documentation_url = "https://docs.rollbar.com/docs/apple"
-  s.social_media_url  = "http://twitter.com/rollbar"
+  s.social_media_url  = "https://twitter.com/rollbar"
   s.resource = "rollbar-logo.png"
 
   s.osx.deployment_target = "12.0"

--- a/RollbarAUL.podspec
+++ b/RollbarAUL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-    s.version      = "3.0.0"
     s.name         = "RollbarAUL"
+    s.version      = "3.0.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -10,13 +10,11 @@ Pod::Spec.new do |s|
                    DESC
     s.homepage     = "https://rollbar.com"
     s.license      = { :type => "MIT", :file => "LICENSE" }
-    s.authors      = { "Rollbar" => "support@rollbar.com",
-                       "Andrey Kornich (Wide Spectrum Computing LLC)" => "akornich@gmail.com",
-                       "Matias Pequeno" => "matias.pequeno@rollbar.com" }
+    s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                       :tag => "#{s.version}" }
+                       :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
-    s.social_media_url  = "http://twitter.com/rollbar"
+    s.social_media_url  = "https://twitter.com/rollbar"
     s.resource = "rollbar-logo.png"
 
     s.osx.deployment_target = "12.0"

--- a/RollbarCocoaLumberjack.podspec
+++ b/RollbarCocoaLumberjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-    s.version      = "3.0.0"
     s.name         = "RollbarCocoaLumberjack"
+    s.version      = "3.0.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -12,9 +12,9 @@ Pod::Spec.new do |s|
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                       :tag => "#{s.version}" }
+                       :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
-    s.social_media_url  = "http://twitter.com/rollbar"
+    s.social_media_url  = "https://twitter.com/rollbar"
     s.resource = "rollbar-logo.png"
 
     s.osx.deployment_target = "12.0"

--- a/RollbarCommon.podspec
+++ b/RollbarCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-    s.version      = "3.0.0"
     s.name         = "RollbarCommon"
+    s.version      = "3.0.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -12,9 +12,9 @@ Pod::Spec.new do |s|
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                       :tag => "#{s.version}" }
+                       :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
-    s.social_media_url  = "http://twitter.com/rollbar"
+    s.social_media_url  = "https://twitter.com/rollbar"
     s.resource = "rollbar-logo.png"
 
     s.osx.deployment_target = "12.0"

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -14,8 +14,7 @@ Pod::Spec.new do |s|
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                       #:tag => s.version.to_s }
-                       :branch => "push_pods" }
+                       :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.social_media_url  = "https://twitter.com/rollbar"
 

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -27,4 +27,6 @@ Pod::Spec.new do |s|
     s.dependency "KSCrash", "~> 1.15"
     s.frameworks = "Foundation"
     s.source_files  = "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
+
+    s.swift_versions = "5.5"
 end

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -1,30 +1,30 @@
 Pod::Spec.new do |s|
-  s.name         = "RollbarCrashReport"
-  s.version      = "3.0.0"
-  s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
-  s.description  = <<-DESC
-                    Find, fix, and resolve errors with Rollbar.
-                    Easily send error data using Rollbar API.
-                    Analyze, de-dupe, send alerts, and prepare the data for further analysis.
-                    Search, sort, and prioritize via the Rollbar dashboard.
-                 DESC
+    s.name         = "RollbarCrashReport"
+    s.version      = "3.0.0"
+    s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
+    s.description  = <<-DESC
+                      Find, fix, and resolve errors with Rollbar.
+                      Easily send error data using Rollbar API.
+                      Analyze, de-dupe, send alerts, and prepare the data for further analysis.
+                      Search, sort, and prioritize via the Rollbar dashboard.
+                  DESC
 
-  s.homepage     = "https://rollbar.com"
-  s.resource     = "rollbar-logo.png"
-  s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.authors      = { "Rollbar" => "support@rollbar.com" }
-  s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                     :tag => s.version.to_s }
-  s.documentation_url = "https://docs.rollbar.com/docs/apple"
-  s.social_media_url  = "http://twitter.com/rollbar"
+    s.homepage     = "https://rollbar.com"
+    s.resource     = "rollbar-logo.png"
+    s.license      = { :type => "MIT", :file => "LICENSE" }
+    s.authors      = { "Rollbar" => "support@rollbar.com" }
+    s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
+                      :tag => s.version.to_s }
+    s.documentation_url = "https://docs.rollbar.com/docs/apple"
+    s.social_media_url  = "https://twitter.com/rollbar"
 
-  s.osx.deployment_target = "12.0"
-  s.ios.deployment_target = "14.0"
-  s.tvos.deployment_target = "14.0"
-  s.watchos.deployment_target = "8.0"
+    s.osx.deployment_target = "12.0"
+    s.ios.deployment_target = "14.0"
+    s.tvos.deployment_target = "14.0"
+    s.watchos.deployment_target = "8.0"
 
-  s.module_name = "RollbarCrashReport"
-  s.dependency "KSCrash", "~> 1.15"
-  s.frameworks = "Foundation"
-  s.source_files  = "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
+    s.module_name = "RollbarCrashReport"
+    s.dependency "KSCrash", "~> 1.15"
+    s.frameworks = "Foundation"
+    s.source_files  = "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
 end

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -30,4 +30,5 @@ Pod::Spec.new do |s|
     s.source_files  = "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
 
     s.swift_versions = "5.5"
+    s.requires_arc = true
 end

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -14,7 +14,8 @@ Pod::Spec.new do |s|
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                      :tag => s.version.to_s }
+                       #:tag => s.version.to_s }
+                       :branch => "push_pods" }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.social_media_url  = "https://twitter.com/rollbar"
 

--- a/RollbarDeploys.podspec
+++ b/RollbarDeploys.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
-    s.version      = "3.0.0"
     s.name         = "RollbarDeploys"
+    s.version      = "3.0.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -9,13 +9,13 @@ Pod::Spec.new do |s|
                       Search, sort, and prioritize via the Rollbar dashboard.
                    DESC
     s.homepage     = "https://rollbar.com"
+    s.resource     = "rollbar-logo.png"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
-                       :tag => "#{s.version}" }
+                       :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
-    s.social_media_url  = "http://twitter.com/rollbar"
-    s.resource = "rollbar-logo.png"
+    s.social_media_url  = "https://twitter.com/rollbar"
 
     s.osx.deployment_target = "12.0"
     s.ios.deployment_target = "14.0"

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -8,7 +8,6 @@ Pod::Spec.new do |s|
                       Analyze, de-dupe, send alerts, and prepare the data for further analysis.
                       Search, sort, and prioritize via the Rollbar dashboard.
                    DESC
-
     s.homepage     = "https://rollbar.com"
     s.resource     = "rollbar-logo.png"
     s.license      = { :type => "MIT", :file => "LICENSE" }
@@ -16,7 +15,7 @@ Pod::Spec.new do |s|
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
                        :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
-    s.social_media_url  = "http://twitter.com/rollbar"
+    s.social_media_url  = "https://twitter.com/rollbar"
 
     s.osx.deployment_target = "12.0"
     s.ios.deployment_target = "14.0"

--- a/podpub.sh
+++ b/podpub.sh
@@ -2,7 +2,7 @@
 shopt -s nullglob
 set -e
 
-declare -a PODSPECS=(RollbarCommon RollbarNotifier RollbarSwift RollbarDeploys RollbarAUL RollbarCocoaLumberjack)
+declare -a PODSPECS=(RollbarCommon RollbarCrashReport RollbarNotifier RollbarSwift RollbarDeploys RollbarAUL RollbarCocoaLumberjack)
 declare -a OPTIONS=()
 
 function help {

--- a/podpub.sh
+++ b/podpub.sh
@@ -15,7 +15,7 @@ function help {
 
 while [ $# -gt 0 ]; do
   case $1 in
-    -v|--verbose)
+    -v|--verbose|--allow-warnings)
       OPTIONS+=($1)
       shift
       ;;

--- a/podpub.sh
+++ b/podpub.sh
@@ -34,13 +34,15 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z ${TAG:=$(git tag --points-at HEAD)} ]; then
-  echo "Error: Couldn't figure out git tag, try providing one with --tag."
-  exit 1
-fi
+  echo "WARN: Couldn't figure out git tag, only lint is available."
 
-for PODSPEC in ${PODSPECS[@]}; do
-  #pod spec lint $(IFS=$' '; echo ${OPTIONS[*]}) $PODSPEC.podspec
-  pod trunk push $(IFS=$' '; echo ${OPTIONS[*]}) $PODSPEC.podspec
-done
+  for PODSPEC in ${PODSPECS[@]}; do
+    pod spec lint $(IFS=$' '; echo ${OPTIONS[*]}) $PODSPEC.podspec
+  done
+else
+  for PODSPEC in ${PODSPECS[@]}; do
+    pod trunk push $(IFS=$' '; echo ${OPTIONS[*]}) $PODSPEC.podspec
+  done
+fi
 
 exit 0


### PR DESCRIPTION
## Description of the change

This PR takes care of the issues starting with Xcode 14.3 where podspec dependencies aren't building:

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix [126159](https://app.shortcut.com/rollbar/story/126159/fix-cocoapods-support)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
