### PR TITLE
Fix evil cocoapods

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.h
@@ -1,7 +1,11 @@
 #ifndef RollbarCrashCollector_h
 #define RollbarCrashCollector_h
 
-#import "KSCrashInstallation.h"
+#if __has_include("KSCrash-umbrella.h")
+@import KSCrash;
+#else
+@import KSCrash_Installations;
+#endif
 
 @import Foundation;
 @import RollbarCommon;

--- a/podpub.sh
+++ b/podpub.sh
@@ -42,6 +42,7 @@ if [ -z ${TAG:=$(git tag --points-at HEAD)} ]; then
 else
   for PODSPEC in ${PODSPECS[@]}; do
     pod trunk push $(IFS=$' '; echo ${OPTIONS[*]}) $PODSPEC.podspec
+    pod repo update
   done
 fi
 


### PR DESCRIPTION
## Description of the change

This properly handles the case where `KSCrash` is used as a Cocoapods dependency, in which case, it's compiled as a single module, whereas it has multiple modules when using any other package manager.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Related issues

- Fix [SC-126159](https://app.shortcut.com/rollbar/story/126159/fix-cocoapods-support)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
