### PR TITLE
Fixed warnings compiling some old ObjC code when using cocoapods

### DIFF
--- a/RollbarAUL.podspec
+++ b/RollbarAUL.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |s|
     s.dependency "RollbarCommon", "~> #{s.version}"
     s.dependency "RollbarNotifier", "~> #{s.version}"
 
+    s.swift_versions = "5.5"
     s.requires_arc = true
     s.xcconfig = {
       "USE_HEADERMAP" => "NO",

--- a/RollbarCocoaLumberjack.podspec
+++ b/RollbarCocoaLumberjack.podspec
@@ -32,5 +32,6 @@ Pod::Spec.new do |s|
     s.dependency "RollbarNotifier", "~> #{s.version}"
     s.dependency "CocoaLumberjack", "~> 3.7.4"
 
+    s.swift_versions = "5.5"
     s.requires_arc = true
 end

--- a/RollbarCommon.podspec
+++ b/RollbarCommon.podspec
@@ -28,5 +28,6 @@ Pod::Spec.new do |s|
 
     s.framework = "Foundation"
 
+    s.swift_versions = "5.5"
     s.requires_arc = true
 end

--- a/RollbarDeploys.podspec
+++ b/RollbarDeploys.podspec
@@ -28,5 +28,6 @@ Pod::Spec.new do |s|
     s.framework = "Foundation"
     s.dependency "RollbarCommon", "~> #{s.version}"
 
+    s.swift_versions = "5.5"
     s.requires_arc = true
 end

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -31,5 +31,6 @@ Pod::Spec.new do |s|
     s.dependency "RollbarCrashReport", "~> #{s.version}"
     s.dependency "KSCrash", "~> 1.15"
 
+    s.swift_versions = "5.5"
     s.requires_arc = true
 end

--- a/RollbarNotifier/Sources/RollbarNotifier/Rollbar.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/Rollbar.m
@@ -12,7 +12,7 @@
 #import "RollbarThread.h"
 #import "RollbarLoggingOptions.h"
 
-static void uncaughtExceptionHandler(NSException * _Nonnull exception) {
+void uncaughtExceptionHandler(NSException * _Nonnull exception) {
     NSArray *backtrace = [exception callStackSymbols];
     //    NSString *platform = [[UIDevice currentDevice] platform];
     //    NSString *version = [[UIDevice currentDevice] systemVersion];

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
@@ -578,7 +578,6 @@ static int selectMultipleRowsCallback(void *info, int columns, char **data, char
 
     NSDictionary<NSString *, NSString *> *result = nil;
     char *sqliteErrorMessage;
-    NSDictionary<NSString *, NSString *> *selectedRow = nil;
     int sqlResult = sqlite3_exec(self->_db, [sql UTF8String], callback, &result, &sqliteErrorMessage);
     if (sqlResult != SQLITE_OK) {
         

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarSender.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarSender.m
@@ -71,7 +71,7 @@
 
     __block NSHTTPURLResponse *httpResponse = nil;
 
-    dispatch_semaphore_t sem = dispatch_semaphore_create(NULL);
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
 
     NSURLSession *session = [NSURLSession sharedSession];
 

--- a/RollbarNotifier/Sources/RollbarNotifier/include/Rollbar.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/include/Rollbar.h
@@ -546,6 +546,6 @@
 // to the end of your: -(BOOL)application:didFinishLaunchingWithOptions: method in AppDelegate.
 // Make sure that the [RollbarInfrastructure sharedInstance] was already configured as early as possible within the:
 // -(BOOL)application:didFinishLaunchingWithOptions: method in AppDelegate.
-static void uncaughtExceptionHandler(NSException * _Nonnull exception);
+extern void uncaughtExceptionHandler(NSException * _Nonnull exception);
 
 #endif //Rollbar_h


### PR DESCRIPTION
## Description of the change

When compiling using Cocoapods, modules use Xcode project files with certain configurations that makes some of our ObjC code throw warnings.

Fixing this, allows us to provide a pod that won't introduce warnings to user's projects.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [x] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-126159](https://app.shortcut.com/rollbar/story/126159/fix-cocoapods-support)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
