### PR TITLE
Import sqlite3 as a sys header to prevent conflicts with Flutter sqlite3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Notes
 
+### 3.0.2
+
+- Import sqlite3 as a system header to prevent conflicts with Flutter's sqlite3 platform-specific libraries.
+
 ### 3.0.1
 
 - This version brings support for Cocoapods and workarounds a [Cocoapods issue](https://github.com/CocoaPods/CocoaPods/issues/11839) in Xcode 14.3.

--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Rollbar"
-  s.version      = "3.0.1"
+  s.version      = "3.0.2"
   s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
   s.description  = <<-DESC
                     Find, fix, and resolve errors with Rollbar.

--- a/RollbarAUL.podspec
+++ b/RollbarAUL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarAUL"
-    s.version      = "3.0.1"
+    s.version      = "3.0.2"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarCocoaLumberjack.podspec
+++ b/RollbarCocoaLumberjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCocoaLumberjack"
-    s.version      = "3.0.1"
+    s.version      = "3.0.2"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarCommon.podspec
+++ b/RollbarCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCommon"
-    s.version      = "3.0.1"
+    s.version      = "3.0.2"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarCrashReport.podspec
+++ b/RollbarCrashReport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCrashReport"
-    s.version      = "3.0.1"
+    s.version      = "3.0.2"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarDeploys.podspec
+++ b/RollbarDeploys.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarDeploys"
-    s.version      = "3.0.1"
+    s.version      = "3.0.2"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarNotifier"
-    s.version      = "3.0.1"
+    s.version      = "3.0.2"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarConfig.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarConfig.m
@@ -14,7 +14,7 @@
 
 #pragma mark - constants
 
-static NSString * const NOTIFIER_VERSION = @"3.0.1";
+static NSString * const NOTIFIER_VERSION = @"3.0.2";
 
 static NSString * const NOTIFIER_NAME = @"rollbar-apple";
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
@@ -4,7 +4,7 @@
 
 @import RollbarCommon;
 
-#import "sqlite3.h"
+#import <sqlite3.h>
 
 //======================================================================================================================
 #pragma mark - Sqlite command execution callbacks


### PR DESCRIPTION
## Description of the change

Our Flutter SDK uses sqlite3 same as our Apple SDK. Flutter, however, requires platform-specific adapters for sqlite3 which means downloading certain libraries to get support: https://pub.dev/packages/sqlite3_flutter_libs.

Unfortunately, this will cause confusion when importing sqlite3. Since we need the system's header, we simply import sqlite3 as a system header and avoid looking into other header locations.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [x] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-122326](https://app.shortcut.com/rollbar/story/122326/excessive-logging-of-processing-saved-items)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
