### PR TITLE
Fixed log level ordering to standard

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarData.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarData.m
@@ -52,11 +52,11 @@ static NSString * const DFK_NOTIFIER = @"notifier";
 
 -(RollbarLevel)level {
     NSString *result = [self safelyGetStringByKey:DFK_LEVEL];
-    return [RollbarLevelUtil RollbarLevelFromString:result];
+    return [RollbarLevelUtil rollbarLevelFromString:result];
 }
 
 -(void)setLevel:(RollbarLevel)value {
-    [self setData:[RollbarLevelUtil RollbarLevelToString:value]
+    [self setData:[RollbarLevelUtil rollbarLevelToString:value]
             byKey:DFK_LEVEL];
 }
 

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarLevel.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarLevel.m
@@ -2,49 +2,39 @@
 
 @implementation RollbarLevelUtil
 
-+ (NSString *) RollbarLevelToString:(RollbarLevel)value; {
-
++ (NSString *)rollbarLevelToString:(RollbarLevel)value {
     switch (value) {
         case RollbarLevel_Debug:
             return @"debug";
+        case RollbarLevel_Info:
+            return @"info";
         case RollbarLevel_Warning:
             return @"warning";
-        case RollbarLevel_Critical:
-            return @"critical";
         case RollbarLevel_Error:
             return @"error";
+        case RollbarLevel_Critical:
+            return @"critical";
         default:
             return @"info";
     }
 }
 
-+ (RollbarLevel) RollbarLevelFromString:(nullable NSString *)value {
-    
-    if (nil == value) {
-        
-        return RollbarLevel_Info; // default case...
-    }
-    else if (NSOrderedSame == [value caseInsensitiveCompare:@"debug"]) {
-
++ (RollbarLevel)rollbarLevelFromString:(nullable NSString *)value {
+    if (value == nil) {
+        return RollbarLevel_Info;
+    } else if ([value caseInsensitiveCompare:@"debug"] == NSOrderedSame) {
         return RollbarLevel_Debug;
-    }
-    else  if (NSOrderedSame == [value caseInsensitiveCompare:@"warning"]) {
-
+    } else if ([value caseInsensitiveCompare:@"info"] == NSOrderedSame) {
+        return RollbarLevel_Info;
+    } else if ([value caseInsensitiveCompare:@"warning"] == NSOrderedSame) {
         return RollbarLevel_Warning;
-    }
-    else  if (NSOrderedSame == [value caseInsensitiveCompare:@"critical"]) {
-
-        return RollbarLevel_Critical;
-    }
-    else  if (NSOrderedSame == [value caseInsensitiveCompare:@"error"]) {
-
+    } else if ([value caseInsensitiveCompare:@"error"] == NSOrderedSame) {
         return RollbarLevel_Error;
-    }
-    else {
-
-        return RollbarLevel_Info; // default case...
+    } else if ([value caseInsensitiveCompare:@"critical"] == NSOrderedSame) {
+        return RollbarLevel_Critical;
+    } else {
+        return RollbarLevel_Info;
     }
 }
 
 @end
-

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarLoggingOptions.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarLoggingOptions.m
@@ -2,7 +2,7 @@
 
 #pragma mark - constants
 
-static RollbarLevel const DEFAULT_LOG_LEVEL = RollbarLevel_Info;
+static RollbarLevel const DEFAULT_LOG_LEVEL = RollbarLevel_Debug;
 static RollbarLevel const DEFAULT_CRASH_LEVEL = RollbarLevel_Error;
 static NSUInteger const DEFAULT_MAX_REPORTS_PER_MINUTE = 60;
 static RollbarRateLimitBehavior const DEFAULT_RATE_LIMIT_BEHAVIOR = RollbarRateLimitBehavior_Drop;
@@ -41,8 +41,8 @@ static NSString * const DFK_REQUEST_ID = @"requestId";
                        requestId:(nullable NSString *)requestId
 {
     self = [super initWithDictionary:@{
-        DFK_LOG_LEVEL: [RollbarLevelUtil RollbarLevelToString:logLevel],
-        DFK_CRASH_LEVEL: [RollbarLevelUtil RollbarLevelToString:crashLevel],
+        DFK_LOG_LEVEL: [RollbarLevelUtil rollbarLevelToString:logLevel],
+        DFK_CRASH_LEVEL: [RollbarLevelUtil rollbarLevelToString:crashLevel],
         DFK_MAX_REPORTS_PER_MINUTE: [NSNumber numberWithUnsignedInteger:maximumReportsPerMinute],
         DFK_RATE_LIMIT_BEHAVIOR: [NSNumber numberWithBool:rateLimitBehavior],
         DFK_IP_CAPTURE_TYPE: [RollbarCaptureIpTypeUtil CaptureIpTypeToString:DEFAULT_IP_CAPTURE_TYPE],
@@ -142,12 +142,12 @@ static NSString * const DFK_REQUEST_ID = @"requestId";
 
 - (RollbarLevel)logLevel {
     NSString *logLevelString = [self safelyGetStringByKey:DFK_LOG_LEVEL];
-    return [RollbarLevelUtil RollbarLevelFromString:logLevelString];
+    return [RollbarLevelUtil rollbarLevelFromString:logLevelString];
 }
 
 - (RollbarLevel)crashLevel {
     NSString *logLevelString = [self safelyGetStringByKey:DFK_CRASH_LEVEL];
-    return [RollbarLevelUtil RollbarLevelFromString:logLevelString];
+    return [RollbarLevelUtil rollbarLevelFromString:logLevelString];
 }
 
 - (NSUInteger)maximumReportsPerMinute {
@@ -202,12 +202,12 @@ static NSString * const DFK_REQUEST_ID = @"requestId";
 @dynamic requestId;
 
 - (void)setLogLevel:(RollbarLevel)level {
-    NSString *levelString = [RollbarLevelUtil RollbarLevelToString:level];
+    NSString *levelString = [RollbarLevelUtil rollbarLevelToString:level];
     [self setString:levelString forKey:DFK_LOG_LEVEL];
 }
 
 - (void)setCrashLevel:(RollbarLevel)level {
-    NSString *levelString = [RollbarLevelUtil RollbarLevelToString:level];
+    NSString *levelString = [RollbarLevelUtil rollbarLevelToString:level];
     [self setString:levelString forKey:DFK_CRASH_LEVEL];
 }
 

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarTelemetryEvent.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarTelemetryEvent.m
@@ -32,7 +32,7 @@ static NSString * const DFK_BODY = @"body";
     RollbarTelemetryBody *body = [RollbarTelemetryEvent createTelemetryBodyWithType:type
                                                                                data:nil];
     self = [self initWithDictionary:@{
-        DFK_LEVEL:[RollbarLevelUtil RollbarLevelToString:level],
+        DFK_LEVEL:[RollbarLevelUtil rollbarLevelToString:level],
         DFK_TYPE:[RollbarTelemetryTypeUtil RollbarTelemetryTypeToString:type],
         DFK_SOURCE:[RollbarSourceUtil RollbarSourceToString:source],
         DFK_TIMESTAMP:[NSNumber numberWithDouble:round(timestamp)],
@@ -48,7 +48,7 @@ static NSString * const DFK_BODY = @"body";
     NSTimeInterval timestamp = NSDate.date.timeIntervalSince1970 * 1000.0;
     RollbarTelemetryType type = [RollbarTelemetryEvent deriveTypeFromBody:body];
     self = [self initWithDictionary:@{
-        DFK_LEVEL:[RollbarLevelUtil RollbarLevelToString:level],
+        DFK_LEVEL:[RollbarLevelUtil rollbarLevelToString:level],
         DFK_TYPE:[RollbarTelemetryTypeUtil RollbarTelemetryTypeToString:type],
         DFK_SOURCE:[RollbarSourceUtil RollbarSourceToString:source],
         DFK_TIMESTAMP:[NSNumber numberWithDouble:round(timestamp)],
@@ -69,7 +69,7 @@ static NSString * const DFK_BODY = @"body";
 -(RollbarLevel)level {
 
     NSString *result = [self getDataByKey:DFK_LEVEL];
-    return [RollbarLevelUtil RollbarLevelFromString:result];
+    return [RollbarLevelUtil rollbarLevelFromString:result];
 }
 
 #pragma mark type

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarTelemetry.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarTelemetry.m
@@ -213,7 +213,7 @@ static dispatch_queue_t fileQueue = nil;
     }
     
     NSTimeInterval timestamp = NSDate.date.timeIntervalSince1970 * 1000.0;
-    NSString *telemetryLvl = [RollbarLevelUtil   RollbarLevelToString:level];
+    NSString *telemetryLvl = [RollbarLevelUtil rollbarLevelToString:level];
     NSString *telemetryType = [RollbarTelemetryTypeUtil RollbarTelemetryTypeToString:type];
     NSDictionary *info = @{@"level": telemetryLvl,
                            @"type": telemetryType,
@@ -336,7 +336,7 @@ static dispatch_queue_t fileQueue = nil;
             [RollbarTelemetryEvent createTelemetryBodyWithType:eventType data:dataItem[@"body"]];
         if (nil != eventBody) {
             
-            RollbarLevel eventLevel = [RollbarLevelUtil RollbarLevelFromString:dataItem[@"level"]];
+            RollbarLevel eventLevel = [RollbarLevelUtil rollbarLevelFromString:dataItem[@"level"]];
             RollbarSource eventSource = [RollbarSourceUtil RollbarSourceFromString:dataItem[@"source"]];
             RollbarTelemetryEvent *event = [[RollbarTelemetryEvent alloc] initWithLevel:eventLevel
                                                                                  source:eventSource

--- a/RollbarNotifier/Sources/RollbarNotifier/include/RollbarLevel.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/include/RollbarLevel.h
@@ -6,11 +6,11 @@
 #pragma mark - RollbarLevel
 
 typedef NS_ENUM(NSUInteger, RollbarLevel) {
-    RollbarLevel_Info,
     RollbarLevel_Debug,
+    RollbarLevel_Info,
     RollbarLevel_Warning,
-    RollbarLevel_Critical,
-    RollbarLevel_Error
+    RollbarLevel_Error,
+    RollbarLevel_Critical
 };
 
 #pragma mark - RollbarLevel utility
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Converts RollbarLevel enum value to its string equivalent or default string.
 /// @param value RollbarLevel enum value
-+ (NSString *) RollbarLevelToString:(RollbarLevel)value;
++ (NSString *)rollbarLevelToString:(RollbarLevel)value;
 
 /// Converts string value into its  RollbarLevel enum value equivalent or default enum value.
 /// @param value input string
-+ (RollbarLevel) RollbarLevelFromString:(nullable NSString *)value;
++ (RollbarLevel)rollbarLevelFromString:(nullable NSString *)value;
 
 @end
 

--- a/RollbarNotifier/Tests/RollbarNotifierTests-ObjC/DTOsTests.m
+++ b/RollbarNotifier/Tests/RollbarNotifierTests-ObjC/DTOsTests.m
@@ -312,7 +312,7 @@
                   );
     
     dto = [[RollbarMutableLoggingOptions alloc] init];
-    XCTAssertTrue(dto.logLevel == RollbarLevel_Info,
+    XCTAssertTrue(dto.logLevel == RollbarLevel_Debug,
                   @"Proper default log level"
                   );
     XCTAssertTrue(dto.crashLevel == RollbarLevel_Error,

--- a/RollbarNotifier/Tests/RollbarNotifierTests/RollbarNotifierDTOsTests.swift
+++ b/RollbarNotifier/Tests/RollbarNotifierTests/RollbarNotifierDTOsTests.swift
@@ -323,7 +323,7 @@ final class RollbarNotifierDTOsTests: XCTestCase {
                       );
         
         dto = RollbarMutableLoggingOptions();
-        XCTAssertTrue(dto.logLevel == .info,
+        XCTAssertTrue(dto.logLevel == .debug,
                       "Proper default log level"
                       );
         XCTAssertTrue(dto.crashLevel == .error,


### PR DESCRIPTION
## Description of the change

This PR fixes the ordering of log levels which was very wrong. This issue was [reported](https://github.com/rollbar/rollbar-apple/issues/291) today.

This incorrect ordering introduces issues when defining minimum level for logging since we use the integer ordering of the enum to check whether we should record a log or not.

This can be seen in the `shouldSkipReporting:` function in `RollbarLogger`: https://github.com/rollbar/rollbar-apple/blob/master/RollbarNotifier/Sources/RollbarNotifier/RollbarLogger.m#L179

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix [SC-126937](https://app.shortcut.com/rollbar/story/126937/apple-sdk-fix-ordering-of-logging-levels)
- Fix https://github.com/rollbar/rollbar-apple/issues/291

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
