### PR TITLE
Fixed warning about ambiguous empty array

### DIFF
--- a/Demos/iosAppSwift/iosAppSwift/ContentView.swift
+++ b/Demos/iosAppSwift/iosAppSwift/ContentView.swift
@@ -178,7 +178,7 @@ struct Example {
 
     func outOfBounds(_ index: Int) {
         print("outOfBounds: \(index)")
-        _ = [][index]
+        _ = [Any]()[index]
     }
 
     func incrementPastEndIndex(_ r: ClosedRange<Int>) {


### PR DESCRIPTION
## Description of the change

Latest version of swiftc now correctly reports type ambiguity when creating empty arrays on some edge cases.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Not tracked

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
