### PR TITLE
Updated podspecs for 3.1.0, added RollbarCrash and removed KSCrash dep

### DIFF
--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Rollbar"
-  s.version      = "3.0.3"
+  s.version      = "3.1.0"
   s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
   s.description  = <<-DESC
                     Find, fix, and resolve errors with Rollbar.
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
                   DESC
 
   s.homepage     = "https://rollbar.com"
+  s.resource     = "rollbar-logo.png"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.authors      = { "Rollbar" => "support@rollbar.com" }
   s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
@@ -17,59 +18,57 @@ Pod::Spec.new do |s|
 
   s.documentation_url = "https://docs.rollbar.com/docs/apple"
   s.social_media_url  = "https://twitter.com/rollbar"
-  s.resource = "rollbar-logo.png"
 
   s.osx.deployment_target = "12.0"
   s.ios.deployment_target = "14.0"
   s.tvos.deployment_target = "14.0"
   s.watchos.deployment_target = "8.0"
 
-  s.module_name  = "RollbarNotifier"
+  s.module_name  = "Rollbar"
   s.requires_arc = true
-  s.frameworks = 'Foundation'
+  s.framework = 'Foundation'
   s.swift_versions = "5.5"
 
   s.pod_target_xcconfig = {
       'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
       'CLANG_CXX_LIBRARY' => 'libc++'
   }
   s.watchos.pod_target_xcconfig = {
       'OTHER_LDFLAGS' => '$(inherited) -framework WatchKit'
   }
 
-  s.source_files  = "RollbarNotifier/Sources/RollbarNotifier/**/*.{h,m}", "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
-  s.public_header_files = "RollbarNotifier/Sources/RollbarNotifier/include/*.h"
-  s.module_map = "RollbarNotifier/Sources/RollbarNotifier/include/module.modulemap"
+  s.source_files =
+    "RollbarNotifier/Sources/RollbarCrash/**/*.{h,c,m}",
+    "RollbarNotifier/Sources/RollbarReport/**/*.swift",
+    "RollbarNotifier/Sources/RollbarNotifier/**/*.{h,m}"
+  s.public_header_files =
+    "RollbarNotifier/Sources/RollbarCrash/include/*.h",
+    "RollbarNotifier/Sources/RollbarNotifier/include/*.h"
+  s.module_map =
+    "RollbarNotifier/Sources/RollbarCrash/include/module.modulemap",
+    "RollbarNotifier/Sources/RollbarNotifier/include/module.modulemap"
 
   s.default_subspecs = ['Common']
-
-  s.dependency "KSCrash", "~> 1.15.27"
 
   s.subspec 'Common' do |sp|
       sp.source_files  = "RollbarCommon/Sources/RollbarCommon/**/*.{h,m}"
       sp.public_header_files = "RollbarCommon/Sources/RollbarCommon/include/*.h"
-      #sp.module_map = "RollbarCommon/Sources/RollbarCommon/include/module.modulemap"
   end
 
   s.subspec 'AUL' do |sp|
       sp.source_files = "RollbarAUL/Sources/RollbarAUL/**/*.{h,m}"
       sp.public_header_files = "RollbarAUL/Sources/RollbarAUL/include/*.h"
-      #sp.module_map = "RollbarAUL/Sources/RollbarAUL/include/module.modulemap"
   end
 
   s.subspec 'CocoaLumberjack' do |sp|
       sp.source_files  = "RollbarCocoaLumberjack/Sources/RollbarCocoaLumberjack/**/*.{h,m}"
       sp.public_header_files = "RollbarCocoaLumberjack/Sources/RollbarCocoaLumberjack/include/*.h"
-      #sp.module_map = "RollbarCocoaLumberjack/Sources/RollbarCocoaLumberjack/include/module.modulemap"
-
-      #sp.static_framework = true
       sp.dependency "CocoaLumberjack", "~> 3.7.4"
   end
 
   s.subspec 'Deploys' do |sp|
       sp.source_files  = "RollbarDeploys/Sources/RollbarDeploys/**/*.{h,m}"
       sp.public_header_files = "RollbarDeploys/Sources/RollbarDeploys/include/*.h"
-      #sp.module_map = "RollbarDeploys/Sources/RollbarDeploys/include/module.modulemap"
   end
 end

--- a/RollbarCocoaLumberjack.podspec
+++ b/RollbarCocoaLumberjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCocoaLumberjack"
-    s.version      = "3.0.3"
+    s.version      = "3.1.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -9,13 +9,13 @@ Pod::Spec.new do |s|
                       Search, sort, and prioritize via the Rollbar dashboard.
                    DESC
     s.homepage     = "https://rollbar.com"
+    s.resource     = "rollbar-logo.png"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
                        :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.social_media_url  = "https://twitter.com/rollbar"
-    s.resource = "rollbar-logo.png"
 
     s.osx.deployment_target = "12.0"
     s.ios.deployment_target = "14.0"

--- a/RollbarCommon.podspec
+++ b/RollbarCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCommon"
-    s.version      = "3.0.3"
+    s.version      = "3.1.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -9,13 +9,13 @@ Pod::Spec.new do |s|
                       Search, sort, and prioritize via the Rollbar dashboard.
                    DESC
     s.homepage     = "https://rollbar.com"
+    s.resource     = "rollbar-logo.png"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.authors      = { "Rollbar" => "support@rollbar.com" }
     s.source       = { :git => "https://github.com/rollbar/rollbar-apple.git",
                        :tag => s.version.to_s }
     s.documentation_url = "https://docs.rollbar.com/docs/apple"
     s.social_media_url  = "https://twitter.com/rollbar"
-    s.resource = "rollbar-logo.png"
 
     s.osx.deployment_target = "12.0"
     s.ios.deployment_target = "14.0"

--- a/RollbarCrash.podspec
+++ b/RollbarCrash.podspec
@@ -1,14 +1,13 @@
 Pod::Spec.new do |s|
-    s.name         = "RollbarCrashReport"
-    s.version      = "3.0.3"
+    s.name         = "RollbarCrash"
+    s.version      = "3.1.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
                       Easily send error data using Rollbar API.
                       Analyze, de-dupe, send alerts, and prepare the data for further analysis.
                       Search, sort, and prioritize via the Rollbar dashboard.
-                  DESC
-
+                   DESC
     s.homepage     = "https://rollbar.com"
     s.resource     = "rollbar-logo.png"
     s.license      = { :type => "MIT", :file => "LICENSE" }
@@ -23,10 +22,12 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = "14.0"
     s.watchos.deployment_target = "8.0"
 
-    s.module_name = "RollbarCrashReport"
-    s.dependency "KSCrash", "~> 1.15"
-    s.frameworks = "Foundation"
-    s.source_files  = "RollbarNotifier/Sources/RollbarCrashReport/**/*.swift"
+    s.module_name = "RollbarCrash"
+    s.source_files  = "RollbarNotifier/Sources/#{s.name}/**/*.{h,c,m}"
+    s.public_header_files = "RollbarNotifier/Sources/#{s.name}/include/*.h"
+    s.module_map = "RollbarNotifier/Sources/#{s.name}/include/module.modulemap"
+
+    s.framework = "Foundation"
 
     s.swift_versions = "5.5"
     s.requires_arc = true

--- a/RollbarDeploys.podspec
+++ b/RollbarDeploys.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarDeploys"
-    s.version      = "3.0.3"
+    s.version      = "3.1.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarNotifier"
-    s.version      = "3.0.3"
+    s.version      = "3.1.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -22,14 +22,15 @@ Pod::Spec.new do |s|
     s.tvos.deployment_target = "14.0"
     s.watchos.deployment_target = "8.0"
 
+    s.module_name = "RollbarNotifier"
     s.source_files  = "#{s.name}/Sources/#{s.name}/**/*.{h,m}"
     s.public_header_files = "#{s.name}/Sources/#{s.name}/include/*.h"
     s.module_map = "#{s.name}/Sources/#{s.name}/include/module.modulemap"
 
     s.framework = "Foundation"
     s.dependency "RollbarCommon", "~> #{s.version}"
-    s.dependency "RollbarCrashReport", "~> #{s.version}"
-    s.dependency "KSCrash", "~> 1.15"
+    s.dependency "RollbarCrash", "~> #{s.version}"
+    s.dependency "RollbarReport", "~> #{s.version}"
 
     s.swift_versions = "5.5"
     s.requires_arc = true

--- a/RollbarReport.podspec
+++ b/RollbarReport.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-    s.name         = "RollbarAUL"
+    s.name         = "RollbarReport"
     s.version      = "3.1.0"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
@@ -18,19 +18,16 @@ Pod::Spec.new do |s|
     s.social_media_url  = "https://twitter.com/rollbar"
 
     s.osx.deployment_target = "12.0"
+    s.ios.deployment_target = "14.0"
+    s.tvos.deployment_target = "14.0"
+    s.watchos.deployment_target = "8.0"
 
-    s.source_files = "#{s.name}/Sources/#{s.name}/**/*.{h,m}"
-    s.public_header_files = "#{s.name}/Sources/#{s.name}/include/*.h"
-    s.module_map = "#{s.name}/Sources/#{s.name}/include/module.modulemap"
+    s.module_name = "RollbarReport"
+    s.source_files  = "RollbarNotifier/Sources/RollbarReport/**/*.swift"
 
     s.framework = "Foundation"
-    s.dependency "RollbarCommon", "~> #{s.version}"
-    s.dependency "RollbarNotifier", "~> #{s.version}"
+    s.dependency "RollbarCrash", "~> #{s.version}"
 
     s.swift_versions = "5.5"
     s.requires_arc = true
-    s.xcconfig = {
-      "USE_HEADERMAP" => "NO",
-      "HEADER_SEARCH_PATHS" => "$(PODS_ROOT)/#{s.name}/#{s.name}/Sources/#{s.name}/**"
-    }
 end


### PR DESCRIPTION
## Description of the change

This PR updates the Cocoapods podspecs:
- Upping version to 3.1.0
- Added new `RollbarCrash.podspec`
- Renamed `RollbarCrashReport` to `RollbarReport`
- Removed `KSCrash` as a dependency

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
