### PR TITLE
Fix `podspec` not using `RollbarCrash` cpp sources

### DIFF
--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   }
 
   s.source_files =
-    "RollbarNotifier/Sources/RollbarCrash/**/*.{h,c,m}",
+    "RollbarNotifier/Sources/RollbarCrash/**/*.{h,c,cpp,m}",
     "RollbarNotifier/Sources/RollbarReport/**/*.swift",
     "RollbarNotifier/Sources/RollbarNotifier/**/*.{h,m}"
   s.public_header_files =

--- a/RollbarCrash.podspec
+++ b/RollbarCrash.podspec
@@ -23,11 +23,18 @@ Pod::Spec.new do |s|
     s.watchos.deployment_target = "8.0"
 
     s.module_name = "RollbarCrash"
-    s.source_files  = "RollbarNotifier/Sources/#{s.name}/**/*.{h,c,m}"
+    s.source_files  = "RollbarNotifier/Sources/#{s.name}/**/*.{h,c,cpp,m}"
     s.public_header_files = "RollbarNotifier/Sources/#{s.name}/include/*.h"
     s.module_map = "RollbarNotifier/Sources/#{s.name}/include/module.modulemap"
 
     s.framework = "Foundation"
+    s.libraries = 'z', 'c++'
+
+    s.pod_target_xcconfig = {
+        'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
+        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
+        'CLANG_CXX_LIBRARY' => 'libc++'
+    }
 
     s.swift_versions = "5.5"
     s.requires_arc = true


### PR DESCRIPTION
## Description of the change

This PR fixes a problem in the `RollbarCrash` `podspec` that missed collecting `.cpp` source files. This also adds some environment compiler directives for Clang and instructs to link to the `z` and `c++` sys libs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
