### PR TITLE
A function decl without a prototype is deprecated in all versions of C

### DIFF
--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor.c
@@ -202,7 +202,7 @@ void rcm_setActiveMonitors(RollbarCrashMonitorType monitorTypes)
     g_activeMonitors = activeMonitors;
 }
 
-RollbarCrashMonitorType rcm_getActiveMonitors()
+RollbarCrashMonitorType rcm_getActiveMonitors(void)
 {
     return g_activeMonitors;
 }

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_AppState.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_AppState.c
@@ -175,7 +175,7 @@ static int addJSONData(const char* const data, const int length, void* const use
 #pragma mark - Utility -
 // ============================================================================
 
-static double getCurrentTime()
+static double getCurrentTime(void)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -352,7 +352,7 @@ void rcstate_initialize(const char* const stateFilePath)
     loadState(g_stateFilePath);
 }
 
-bool rcstate_reset()
+bool rcstate_reset(void)
 {
     if(g_isEnabled)
     {
@@ -472,7 +472,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -498,7 +498,7 @@ static void addContextualInfoToEvent(RollbarCrash_MonitorContext* eventContext)
     }
 }
 
-RollbarCrashMonitorAPI* rcm_appstate_getAPI()
+RollbarCrashMonitorAPI* rcm_appstate_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_Deadlock.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_Deadlock.m
@@ -172,7 +172,7 @@ static NSTimeInterval g_watchdogInterval = 0;
 #pragma mark - API -
 // ============================================================================
 
-static void initialize()
+static void initialize(void)
 {
     static bool isInitialized = false;
     if(!isInitialized)
@@ -202,12 +202,12 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
 
-RollbarCrashMonitorAPI* rcm_deadlock_getAPI()
+RollbarCrashMonitorAPI* rcm_deadlock_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_MachException.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_MachException.c
@@ -400,7 +400,7 @@ static void* handleExceptions(void* const userData)
 #pragma mark - API -
 // ============================================================================
 
-static void uninstallExceptionHandler()
+static void uninstallExceptionHandler(void)
 {
     RCLOG_DEBUG("Uninstalling mach exception handler.");
     
@@ -444,7 +444,7 @@ static void uninstallExceptionHandler()
     RCLOG_DEBUG("Mach exception handlers uninstalled.");
 }
 
-static bool installExceptionHandler()
+static bool installExceptionHandler(void)
 {
     RCLOG_DEBUG("Installing mach exception handler.");
 
@@ -576,7 +576,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -595,7 +595,7 @@ static void addContextualInfoToEvent(struct RollbarCrash_MonitorContext* eventCo
 
 #endif
 
-RollbarCrashMonitorAPI* rcm_machexception_getAPI()
+RollbarCrashMonitorAPI* rcm_machexception_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_NSException.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_NSException.m
@@ -146,12 +146,12 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
 
-RollbarCrashMonitorAPI* rcm_nsexception_getAPI()
+RollbarCrashMonitorAPI* rcm_nsexception_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_Signal.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_Signal.c
@@ -119,7 +119,7 @@ static void handleSignal(int sigNum, siginfo_t* signalInfo, void* userContext)
 #pragma mark - API -
 // ============================================================================
 
-static bool installSignalHandler()
+static bool installSignalHandler(void)
 {
     RCLOG_DEBUG("Installing signal handler.");
 
@@ -226,7 +226,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -241,7 +241,7 @@ static void addContextualInfoToEvent(struct RollbarCrash_MonitorContext* eventCo
 
 #endif
 
-RollbarCrashMonitorAPI* rcm_signal_getAPI()
+RollbarCrashMonitorAPI* rcm_signal_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_System.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_System.m
@@ -233,7 +233,7 @@ static const char* uuidBytesToString(const uint8_t* uuidBytes)
  *
  * @return Executable path.
  */
-static NSString* getExecutablePath()
+static NSString* getExecutablePath(void)
 {
     NSBundle* mainBundle = [NSBundle mainBundle];
     NSDictionary* infoDict = [mainBundle infoDictionary];
@@ -246,7 +246,7 @@ static NSString* getExecutablePath()
  *
  * @return The UUID.
  */
-static const char* getAppUUID()
+static const char* getAppUUID(void)
 {
     const char* result = nil;
     
@@ -318,7 +318,7 @@ static const char* getCPUArchForCPUType(cpu_type_t cpuType, cpu_subtype_t subTyp
     return NULL;
 }
 
-static const char* getCurrentCPUArch()
+static const char* getCurrentCPUArch(void)
 {
     const char* result = getCPUArchForCPUType(rcsysctl_int32ForName("hw.cputype"),
                                             rcsysctl_int32ForName("hw.cpusubtype"));
@@ -334,7 +334,7 @@ static const char* getCurrentCPUArch()
  *
  * @return YES if the device is jailbroken.
  */
-static bool isJailbroken()
+static bool isJailbroken(void)
 {
     return rcdl_imageNamed("MobileSubstrate", false) != UINT32_MAX;
 }
@@ -343,7 +343,7 @@ static bool isJailbroken()
  *
  * @return YES if the app was built in debug mode.
  */
-static bool isDebugBuild()
+static bool isDebugBuild(void)
 {
 #ifdef DEBUG
     return YES;
@@ -356,7 +356,7 @@ static bool isDebugBuild()
  *
  * @return YES if this is a simulator build.
  */
-static bool isSimulatorBuild()
+static bool isSimulatorBuild(void)
 {
 #if TARGET_OS_SIMULATOR
     return YES;
@@ -369,7 +369,7 @@ static bool isSimulatorBuild()
  *
  * @return App Store receipt for iOS 7+, nil otherwise.
  */
-static NSString* getReceiptUrlPath()
+static NSString* getReceiptUrlPath(void)
 {
     NSString* path = nil;
 #if RollbarCrashCRASH_HOST_IOS
@@ -393,7 +393,7 @@ static NSString* getReceiptUrlPath()
  *
  * @return The stringified hex representation of the hash for this device + app.
  */
-static const char* getDeviceAndAppHash()
+static const char* getDeviceAndAppHash(void)
 {
     NSMutableData* data = nil;
     
@@ -441,7 +441,7 @@ static const char* getDeviceAndAppHash()
  *
  * @return YES if this is a testing build.
  */
-static bool isTestBuild()
+static bool isTestBuild(void)
 {
     return [getReceiptUrlPath().lastPathComponent isEqualToString:@"sandboxReceipt"];
 }
@@ -451,7 +451,7 @@ static bool isTestBuild()
  *
  * @return YES if there is an app store receipt.
  */
-static bool hasAppStoreReceipt()
+static bool hasAppStoreReceipt(void)
 {
     NSString* receiptPath = getReceiptUrlPath();
     if(receiptPath == nil)
@@ -464,7 +464,7 @@ static bool hasAppStoreReceipt()
     return isAppStoreReceipt && receiptExists;
 }
 
-static const char* getBuildType()
+static const char* getBuildType(void)
 {
     if(isSimulatorBuild())
     {
@@ -485,7 +485,7 @@ static const char* getBuildType()
     return "unknown";
 }
 
-static uint64_t getStorageSize()
+static uint64_t getStorageSize(void)
 {
     NSNumber* storageSize = [[[NSFileManager defaultManager] attributesOfFileSystemForPath:NSHomeDirectory() error:nil] objectForKey:NSFileSystemSize];
     return storageSize.unsignedLongLongValue;
@@ -495,7 +495,7 @@ static uint64_t getStorageSize()
 #pragma mark - API -
 // ============================================================================
 
-static void initialize()
+static void initialize(void)
 {
     static bool isInitialized = false;
     if(!isInitialized)
@@ -588,7 +588,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -632,7 +632,7 @@ static void addContextualInfoToEvent(RollbarCrash_MonitorContext* eventContext)
     }
 }
 
-RollbarCrashMonitorAPI* rcm_system_getAPI()
+RollbarCrashMonitorAPI* rcm_system_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_User.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_User.c
@@ -105,12 +105,12 @@ static void setEnabled(bool isEnabled)
     g_isEnabled = isEnabled;
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
 
-RollbarCrashMonitorAPI* rcm_user_getAPI()
+RollbarCrashMonitorAPI* rcm_user_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_Zombie.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_Zombie.c
@@ -139,7 +139,7 @@ static void handleDealloc_ ## CLASS(id self, SEL _cmd) \
     fn f = (fn)g_originalDealloc_ ## CLASS; \
     f(self, _cmd); \
 } \
-static void installDealloc_ ## CLASS() \
+static void installDealloc_ ## CLASS(void) \
 { \
     Method method = class_getInstanceMethod(objc_getClass(#CLASS), sel_registerName("dealloc")); \
     g_originalDealloc_ ## CLASS = method_getImplementation(method); \
@@ -154,7 +154,7 @@ static void installDealloc_ ## CLASS() \
 CREATE_ZOMBIE_HANDLER_INSTALLER(NSObject)
 CREATE_ZOMBIE_HANDLER_INSTALLER(NSProxy)
 
-static void install()
+static void install(void)
 {
     unsigned cacheSize = CACHE_SIZE;
     g_zombieHashMask = cacheSize - 1;
@@ -224,7 +224,7 @@ static void setEnabled(bool isEnabled)
     }
 }
 
-static bool isEnabled()
+static bool isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -239,7 +239,7 @@ static void addContextualInfoToEvent(RollbarCrash_MonitorContext* eventContext)
     }
 }
 
-RollbarCrashMonitorAPI* rcm_zombie_getAPI()
+RollbarCrashMonitorAPI* rcm_zombie_getAPI(void)
 {
     static RollbarCrashMonitorAPI api =
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrash.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrash.m
@@ -58,7 +58,7 @@
 @end
 
 
-static NSString* getBundleName()
+static NSString* getBundleName(void)
 {
     NSString* bundleName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
     if(bundleName == nil)
@@ -68,7 +68,7 @@ static NSString* getBundleName()
     return bundleName;
 }
 
-static NSString* getBasePath()
+static NSString* getBasePath(void)
 {
     NSArray* directories = NSSearchPathForDirectoriesInDomains(NSCachesDirectory,
                                                                NSUserDomainMask,

--- a/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashC.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashC.c
@@ -325,7 +325,7 @@ void rc_notifyAppCrash(void)
     rcstate_notifyAppCrash();
 }
 
-int rc_getReportCount()
+int rc_getReportCount(void)
 {
     return rccrs_getReportCount();
 }
@@ -365,7 +365,7 @@ int64_t rc_addUserReport(const char* report, int reportLength)
     return rccrs_addUserReport(report, reportLength);
 }
 
-void rc_deleteAllReports()
+void rc_deleteAllReports(void)
 {
     rccrs_deleteAllReports();
 }

--- a/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashCachedData.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashCachedData.c
@@ -55,7 +55,7 @@ static _Atomic(int) g_semaphoreCount;
 static bool g_searchQueueNames = false;
 static bool g_hasThreadStarted = false;
 
-static void updateThreadList()
+static void updateThreadList(void)
 {
     const task_t thisTask = mach_task_self();
     int oldThreadsCount = g_allThreadsCount;
@@ -185,7 +185,7 @@ void rcccd_init(int pollingIntervalInSeconds)
     pthread_attr_destroy(&attr);
 }
 
-void rcccd_freeze()
+void rcccd_freeze(void)
 {
     if(g_semaphoreCount++ <= 0)
     {
@@ -194,7 +194,7 @@ void rcccd_freeze()
     }
 }
 
-void rcccd_unfreeze()
+void rcccd_unfreeze(void)
 {
     if(--g_semaphoreCount < 0)
     {

--- a/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashReportStore.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashReportStore.c
@@ -61,7 +61,7 @@ static int compareInt64(const void* a, const void* b)
     return 0;
 }
 
-static inline int64_t getNextUniqueID()
+static inline int64_t getNextUniqueID(void)
 {
     return g_nextUniqueIDHigh + g_nextUniqueIDLow++;
 }
@@ -82,7 +82,7 @@ static int64_t getReportIDFromFilename(const char* filename)
     return reportID;
 }
 
-static int getReportCount()
+static int getReportCount(void)
 {
     int count = 0;
     DIR* dir = opendir(g_reportsPath);
@@ -138,7 +138,7 @@ done:
     return index;
 }
 
-static void pruneReports()
+static void pruneReports(void)
 {
     int reportCount = getReportCount();
     if(reportCount > g_maxReportCount)
@@ -153,7 +153,7 @@ static void pruneReports()
     }
 }
 
-static void initializeIDs()
+static void initializeIDs(void)
 {
     time_t rawTime;
     time(&rawTime);
@@ -194,7 +194,7 @@ int64_t rccrs_getNextCrashReport(char* crashReportPathBuffer)
     return nextID;
 }
 
-int rccrs_getReportCount()
+int rccrs_getReportCount(void)
 {
     pthread_mutex_lock(&g_mutex);
     int count = getReportCount();
@@ -256,7 +256,7 @@ done:
     return currentID;
 }
 
-void rccrs_deleteAllReports()
+void rccrs_deleteAllReports(void)
 {
     pthread_mutex_lock(&g_mutex);
     rcfu_deleteContentsOfPath(g_reportsPath);

--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashDynamicLinker.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashDynamicLinker.c
@@ -383,7 +383,7 @@ static void getCrashInfo(const struct mach_header* header, RollbarCrashBinaryIma
     }
 }
 
-int rcdl_imageCount()
+int rcdl_imageCount(void)
 {
     return (int)_dyld_image_count();
 }

--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashLogger.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashLogger.c
@@ -247,7 +247,7 @@ bool rclog_setLogFilename(const char* filename, bool overwrite)
 
 #endif
 
-bool rclog_clearLogFile()
+bool rclog_clearLogFile(void)
 {
     return rclog_setLogFilename(g_logFilename, true);
 }

--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashMachineContext.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashMachineContext.c
@@ -96,7 +96,7 @@ static inline bool getThreadList(RollbarCrashMachineContext* context)
     return true;
 }
 
-int rcmc_contextSize()
+int rcmc_contextSize(void)
 {
     return sizeof(RollbarCrashMachineContext);
 }

--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashThread.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashThread.c
@@ -39,7 +39,7 @@
 #include <sys/sysctl.h>
 
 
-RollbarCrashThread rcthread_self()
+RollbarCrashThread rcthread_self(void)
 {
     thread_t thread_self = mach_thread_self();
     mach_port_deallocate(mach_task_self(), thread_self);


### PR DESCRIPTION
## Description of the change

This PR fixes a warning that would only show up when integrating with Cocoapods and is related to our recent `KSCrash` integration.

The warning is a valid one: _"A function decl without a prototype is deprecated in all versions of C"_

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
