### PR TITLE
Renamed RollbarCrashReport to RollbarRawCrashReport in RollbarNotifier

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarBody.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarBody.m
@@ -1,7 +1,7 @@
 #import "RollbarBody.h"
 
 #import "RollbarMessage.h"
-#import "RollbarCrashReport.h"
+#import "RollbarRawCrashReport.h"
 #import "RollbarTrace.h"
 #import "RollbarTelemetry.h"
 #import "RollbarTelemetryEvent.h"
@@ -27,15 +27,15 @@ static NSString * const DFK_CRASH_REPORT = @"crash_report";
     [self setDictionary:message.jsonFriendlyData forKey:DFK_MESSAGE];
 }
 
-- (nullable RollbarCrashReport *)crashReport {
+- (nullable RollbarRawCrashReport *)crashReport {
     id data = [self getDataByKey:DFK_CRASH_REPORT];
     if (data != nil) {
-        return [[RollbarCrashReport alloc] initWithDictionary:data];
+        return [[RollbarRawCrashReport alloc] initWithDictionary:data];
     }
     return nil;
 }
 
-- (void)setCrashReport:(RollbarCrashReport *)crashReport {
+- (void)setCrashReport:(RollbarRawCrashReport *)crashReport {
     [self setDictionary:crashReport.jsonFriendlyData forKey:DFK_CRASH_REPORT];
 }
 
@@ -132,7 +132,7 @@ static NSString * const DFK_CRASH_REPORT = @"crash_report";
     
     self = [super initWithDictionary:@{
         DFK_MESSAGE: [NSNull null],
-        DFK_CRASH_REPORT: [[RollbarCrashReport alloc] initWithRawCrashReport:crashReport].jsonFriendlyData,
+        DFK_CRASH_REPORT: [[RollbarRawCrashReport alloc] initWithRawCrashReport:crashReport].jsonFriendlyData,
         DFK_TRACE: [NSNull null],
         // if/when we do allow a trace side-by-side with the crash report use the following line instead of code line above:
         //DFK_TRACE: [[RollbarTrace alloc] initWithCrashReport:crashReport].jsonFriendlyData,

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarRawCrashReport.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarRawCrashReport.m
@@ -1,9 +1,8 @@
-#import "RollbarCrashReport.h"
-#import <Foundation/Foundation.h>
+#import "RollbarRawCrashReport.h"
 
 static NSString * const DFK_RAW = @"raw";
 
-@implementation RollbarCrashReport
+@implementation RollbarRawCrashReport
 
 #pragma mark - Properties
 

--- a/RollbarNotifier/Sources/RollbarNotifier/include/RollbarBody.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/include/RollbarBody.h
@@ -6,7 +6,7 @@
 @class RollbarTelemetry;
 @class RollbarTrace;
 @class RollbarMessage;
-@class RollbarCrashReport;
+@class RollbarRawCrashReport;
 @class RollbarTelemetryEvent;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Payload Option 4: "crash_report"
 // Only one of "trace", "trace_chain", "message", or "crash_report" should be present.
-@property (nonatomic, strong, nullable) RollbarCrashReport *crashReport;
+@property (nonatomic, strong, nullable) RollbarRawCrashReport *crashReport;
 
 #pragma mark - Optional properties
 

--- a/RollbarNotifier/Sources/RollbarNotifier/include/RollbarPayloadDTOs.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/include/RollbarPayloadDTOs.h
@@ -16,7 +16,7 @@
 #import "RollbarCallStackFrame.h"
 #import "RollbarCallStackFrameContext.h"
 #import "RollbarException.h"
-#import "RollbarCrashReport.h"
+#import "RollbarRawCrashReport.h"
 #import "RollbarConfig.h"
 #import "RollbarServerConfig.h"
 #import "RollbarDestination.h"

--- a/RollbarNotifier/Sources/RollbarNotifier/include/RollbarRawCrashReport.h
+++ b/RollbarNotifier/Sources/RollbarNotifier/include/RollbarRawCrashReport.h
@@ -1,12 +1,12 @@
-#ifndef RollbarCrashReport_h
-#define RollbarCrashReport_h
+#ifndef RollbarRawCrashReport_h
+#define RollbarRawCrashReport_h
 
 @import RollbarCommon;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Crash report payload element
-@interface RollbarCrashReport : RollbarDTO
+@interface RollbarRawCrashReport : RollbarDTO
 
 #pragma mark - Properties
 
@@ -25,4 +25,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
-#endif //RollbarCrashReport_h
+#endif //RollbarRawCrashReport_h


### PR DESCRIPTION
## Description of the change

This PR renames `RollbarNotifier.RollbarCrashReport` to `RollbarNotifier.RollbarRawCrashReport` to avoid name collisions with `RollbarCrash.RollbarCrashReport` when integrating Rollbar via Cocoapods.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
