### PR TITLE
Fixed C warning for func decl without prototype

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
@@ -6,7 +6,7 @@
 
 @import RollbarReport;
 
-static bool isDebuggerAttached() {
+static bool isDebuggerAttached(void) {
     static bool attached = false;
 
     static dispatch_once_t token;


### PR DESCRIPTION
## Description of the change

This PR fixes a C warning for a function declaration without prototype. The warning is valid, though only pops up when integrating the Apple SDK via Cocoapods on Xcode 14.3.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
