### PR TITLE
Fixed UTF8 character encoding issue when retrieving persisted payloads

### DIFF
--- a/Examples/RollbarDemo/RollbarDemo/ContentView.swift
+++ b/Examples/RollbarDemo/RollbarDemo/ContentView.swift
@@ -110,7 +110,7 @@ struct Example {
     /// Log a single informational message to Rollbar.
     func logMessage() {
         Rollbar.infoMessage(
-            "Rollbar is up and running! Enjoy your remote error and log monitoring...",
+            "Rollbar is up and running! 😁",
             data: ["key_x": "value_x", "key_y": "value_y"])
     }
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
@@ -55,18 +55,19 @@ static int selectMultipleRowsCallback(void *info, int columns, char **data, char
 {
     defaultOnSelectCallback(info, columns, data, column);
 
-    NSMutableArray<NSDictionary<NSString *, NSString *> *> *__strong*result =
-    (NSMutableArray<NSDictionary<NSString *, NSString *> *> *__strong*)info;
+    typedef NSMutableDictionary<NSString *, NSString *> RBPayload;
+    typedef NSMutableArray<RBPayload *> RBPayloads;
+
+    RBPayloads * __strong *result = (RBPayloads * __strong *)info;
     if (!*result) {
-        *result = [NSMutableArray<NSDictionary<NSString *, NSString *> *> array];
+        *result = [RBPayloads array];
     }
     
-    NSMutableDictionary<NSString *, NSString *> *row =
-    [NSMutableDictionary<NSString *, NSString *> dictionaryWithCapacity:columns];
+    RBPayload *row = [RBPayload dictionaryWithCapacity:columns];
         
     for (int i = 0; i < columns; i++) {
-        NSString *key = [NSString stringWithFormat:@"%s", column[i]];
-        NSString *value = [NSString stringWithFormat:@"%s", data[i]];
+        NSString *key = [[NSString alloc] initWithUTF8String:column[i]];
+        NSString *value = [[NSString alloc] initWithUTF8String:data[i]];
         row[key] = value;
     }
     


### PR DESCRIPTION
## Description of the change

This PR fixes a character encoding issue when retrieving persisted payloads where strings weren't being read as UTF8 resulting in garbled strings.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- [SC-127180](https://app.shortcut.com/rollbar/story/127180/character-encoding-works-differently-compared-to-rollbar-ios-sdk)
- Fixes https://github.com/rollbar/rollbar-apple/issues/294
- Fixes https://github.com/rollbar/rollbar-apple/issues/295

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
