### PR TITLE
Fix unhandled status responses resulting in bad requests being sent repeatedly

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
@@ -90,10 +90,11 @@
     }
     
     switch (reply.statusCode) {
+        case 401: // unauthorized
         case 403: // access denied
         case 404: // not found
             RBLog(@"\tQueuing record");
-            //let's hold on on posting to the destination for 1 minute:
+            // let's hold on on posting to the destination for 1 minute:
             self->_nextEarliestPost = [NSDate dateWithTimeIntervalSinceNow:60];
             self->_localWindowCount = 0;
             self->_serverWindowRemainingCount = 0;
@@ -113,7 +114,7 @@
         case 422: // unprocessable entity
         default:
             RBLog(@"\tDropping record");
-            self->_nextServerWindowStart = [NSDate dateWithTimeIntervalSinceNow:reply.remainingSeconds];;
+            self->_nextServerWindowStart = [NSDate dateWithTimeIntervalSinceNow:reply.remainingSeconds];
             self->_serverWindowRemainingCount = reply.remainingCount;
             if (self->_nextLocalWindowStart) {
                 self->_localWindowCount = 0;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarThread.m
@@ -553,10 +553,10 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
     switch (reply.statusCode) {
         case 200: // OK
             return RollbarTriStateFlag_On; // the payload was successfully transmitted
-        case 400: // bad request
-        case 413: // request entity too large
-        case 422: // unprocessable entity
-            return RollbarTriStateFlag_Off; // unecceptable request/payload - should be dropped
+        case 401: // unauthorized
+        case 403: // access denied
+        case 404: // not found
+            return RollbarTriStateFlag_None; // worth retrying later
         case 429: // too many requests
             switch (self.rateLimitBehavior) {
                 case RollbarRateLimitBehavior_Queue:
@@ -565,10 +565,12 @@ static NSTimeInterval const DEFAULT_PAYLOAD_LIFETIME_SECONDS = 24 * 60 * 60;
                 default:
                     return RollbarTriStateFlag_Off;
             }
-        case 403: // access denied
-        case 404: // not found
+        case 400: // bad request
+        case 413: // request entity too large
+        case 422: // unprocessable entity
         default:
-            return RollbarTriStateFlag_None; // worth retrying later
+            return RollbarTriStateFlag_Off; // unacceptable request/payload - should be dropped
+
     }
 }
 


### PR DESCRIPTION
## Description of the change

This PR fixes an issue where unhandled server responses were being set for immediate reprocessing _and_ being queued for retry instead of being dropped.

The logic is excessively complicated and it's not easy to explain, so 🐻 with me.

Depending on the server response, we decide either to requeue an occurrence to be sent 60s later (eg. 503), or immediately drop it (eg. 400).

_The timing aspect (do it after 60s or immediately), and the decision (drop or queue) are done separately._

- `A` _first_, we check the http status response and decide whether we want to reprocess in 60s, or immediately. (yeah)
- `B` _then, later on, in an entirely different place,_ we check the http status response and decide whether we want to drop the request or queue it.

The way we were processing unhandled server responses was inverted in first and second. So, during `A`, we'd instruct the request to be reprocessed immediately (cause it has to be dropped), ***but*** during `B`, we'd instruct the request to be queued instead of dropped.

The result was a failed request that was being resent repeatedly and immediately, forever and ever (because it wasn't being remove from the db either).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix [SC-128837](https://app.shortcut.com/rollbar/story/128837/unhandled-http-status-responses-lead-to-bad-requests-being-sent-repeatedly-forever)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
