### PR TITLE
Can't use NSInteger/NSUInteger as format arguments

### DIFF
--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarDestinationRecord.m
@@ -158,9 +158,9 @@
                              ,
                              super.description,
                              self->_destinationID,
-                             self->_localWindowLimit,
-                             self->_localWindowCount,
-                             self->_serverWindowRemainingCount,
+                             (unsigned long)self->_localWindowLimit,
+                             (unsigned long)self->_localWindowCount,
+                             (unsigned long)self->_serverWindowRemainingCount,
                              self->_nextLocalWindowStart,
                              self->_nextServerWindowStart,
                              self->_nextEarliestPost];

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadPostReply.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadPostReply.m
@@ -47,10 +47,10 @@ static NSString * const RESPONSE_HEADER_REMAINING_SECONDS = @"x-rate-limit-remai
                              "   nextPostTime:     %@\n"
                              ,
                              super.description,
-                             self->_statusCode,
-                             self->_rateLimit,
-                             self->_remainingCount,
-                             self->_remainingSeconds,
+                             (long)self->_statusCode,
+                             (unsigned long)self->_rateLimit,
+                             (unsigned long)self->_remainingCount,
+                             (unsigned long)self->_remainingSeconds,
                              self->_nextPostTime
     ];
     return description;

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadRepository.m
@@ -306,7 +306,7 @@ static int selectMultipleRowsCallback(void *info, int columns, char **data, char
       escapedConfig,
       escapedPayload,
       destinationID,
-      [timeStamp integerValue]
+      (long)[timeStamp integerValue]
     ];
     
     if (NO == [self executeSql:sql]) {
@@ -363,8 +363,8 @@ static int selectMultipleRowsCallback(void *info, int columns, char **data, char
     NSString *sql = [NSString stringWithFormat:
                          @"SELECT * FROM payloads WHERE destination_key = '%@' LIMIT %lu OFFSET %lu",
                      destinationID,
-                     limit,
-                     offset
+                     (unsigned long)limit,
+                     (unsigned long)offset
     ];
     
     NSArray<NSDictionary<NSString *, NSString *> *> *result =
@@ -382,7 +382,9 @@ static int selectMultipleRowsCallback(void *info, int columns, char **data, char
                                                                           andLimit:(NSUInteger)limit {
 
     NSString *sql =
-    [NSString stringWithFormat:@"SELECT * FROM payloads LIMIT %lu OFFSET %lu", limit, offset];
+    [NSString stringWithFormat:@"SELECT * FROM payloads LIMIT %lu OFFSET %lu",
+     (unsigned long)limit,
+     (unsigned long)offset];
     
     NSArray<NSDictionary<NSString *, NSString *> *> *result =
     [self selectMultipleRowsWithSql:sql andCallback:selectMultipleRowsCallback];


### PR DESCRIPTION
## Description of the change

This PR fixes a warning that for some reason only shows up when compiling for watchOS.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Not tracked

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
