### PR TITLE
Fix pods issue when using RollbarCrash as an internal dependency

### DIFF
--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -34,4 +34,8 @@ Pod::Spec.new do |s|
 
     s.swift_versions = "5.5"
     s.requires_arc = true
+
+    s.osx.xcconfig = {
+      "USE_HEADERMAP" => "NO"
+    }
 end


### PR DESCRIPTION
## Description of the change

This PR fixes an issue with our `RollbarNotifier` `podspec` where `RollbarCrash` wouldn't compile when targeting macOS (all other OS work fine) since cocoapods was duplicating headers during linting because god knows why, and this fixes it because whatever.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
