### PR TITLE
Add RollbarCommon pub header dir to search path of Notifier podspec

### DIFF
--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -36,6 +36,9 @@ Pod::Spec.new do |s|
     s.requires_arc = true
 
     s.osx.xcconfig = {
-      "USE_HEADERMAP" => "NO"
+      "USE_HEADERMAP" => "NO",
+      "HEADER_SEARCH_PATHS" => \
+        "$(PODS_ROOT)/#{s.name}/#{s.name}/Sources/#{s.name}/** " \
+        "$(PODS_ROOT)/RollbarCommon/RollbarCommon/Sources/RollbarCommon/include"
     }
 end


### PR DESCRIPTION
## Description of the change

More cocoapods stuff, because we don't use header maps, RollbarNotifier can't find _one_ of the headers in RollbarCommon, one. It can find everything else.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [x] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
