### PR TITLE
Updated CocoaLumberjack integration to 3.8.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "RollbarCocoaLumberjack", targets: ["RollbarCocoaLumberjack"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.7.4"),
+        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.8.0"),
     ],
     targets: [
         .target(

--- a/RollbarCocoaLumberjack.podspec
+++ b/RollbarCocoaLumberjack.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
     s.framework = "Foundation"
     s.dependency "RollbarCommon", "~> #{s.version}"
     s.dependency "RollbarNotifier", "~> #{s.version}"
-    s.dependency "CocoaLumberjack", "~> 3.7.4"
+    s.dependency "CocoaLumberjack", "~> 3.8.0"
 
     s.swift_versions = "5.5"
     s.requires_arc = true

--- a/RollbarCocoaLumberjack/Package.swift
+++ b/RollbarCocoaLumberjack/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(path: "../RollbarCommon"),
         .package(path: "../RollbarNotifier"),
         .package(path: "../UnitTesting"),
-        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.7.4"),
+        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.8.0"),
     ],
     targets: [
         .target(

--- a/RollbarSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RollbarSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
       "state" : {
-        "revision" : "80ada1f753b0d53d9b57c465936a7c4169375002",
-        "version" : "3.7.4"
+        "revision" : "0188d31089b5881a269e01777be74c7316924346",
+        "version" : "3.8.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-        "version" : "1.4.2"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     }
   ],


### PR DESCRIPTION
## Description of the change

This PR updates the CocoaLumberjack version we integrate with to 3.8.0 to provide proper support for Xcode 14.3 onwards.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
