### PR TITLE
Fix archiving release issues when integrating through latest Cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Release Notes
 
+### 3.1.1
+
+- Fixed archiving issue when integrating the SDK using Cocoapods.
+  - Updating is unnecessary if using any other package manager like SPM.
+
 ### 3.1.0
 
 - The `KSCrash` dependency has been completely dropped.

--- a/Examples/Integration/CocoapodsApp/Podfile.lock
+++ b/Examples/Integration/CocoapodsApp/Podfile.lock
@@ -9,27 +9,21 @@ PODS:
     - RollbarCrash (~> 3.1.0)
 
 DEPENDENCIES:
-  - RollbarCommon (from `../../../`)
-  - RollbarCrash (from `../../../`)
-  - RollbarNotifier (from `../../../`)
-  - RollbarReport (from `../../../`)
+  - RollbarNotifier (~> 3.1.0)
 
-EXTERNAL SOURCES:
-  RollbarCommon:
-    :path: "../../../"
-  RollbarCrash:
-    :path: "../../../"
-  RollbarNotifier:
-    :path: "../../../"
-  RollbarReport:
-    :path: "../../../"
+SPEC REPOS:
+  trunk:
+    - RollbarCommon
+    - RollbarCrash
+    - RollbarNotifier
+    - RollbarReport
 
 SPEC CHECKSUMS:
   RollbarCommon: 125fb7e9fa63ea79ef33ee0f0e50456bb9f9cdf5
   RollbarCrash: d831f9c067bbe2147080a700c0a7ebc346d31db3
-  RollbarNotifier: c712946d79d82103fc2ae07956c768ba8705dee2
-  RollbarReport: 2f42cb47ce9f0be32c5e040e702f936b99e62542
+  RollbarNotifier: 3213f4466b7f239c06d67e2c4963177e694df91b
+  RollbarReport: 55693c386a511cd37272fb2bfc8a6c1b333cd749
 
-PODFILE CHECKSUM: 67f7079dea0a413cbd163635c7d721b213865260
+PODFILE CHECKSUM: 5bf17b88c31394fd8e7ce6804c149a42c077e1a8
 
 COCOAPODS: 1.12.1

--- a/Examples/Integration/CocoapodsFramework/Podfile.lock
+++ b/Examples/Integration/CocoapodsFramework/Podfile.lock
@@ -9,27 +9,21 @@ PODS:
     - RollbarCrash (~> 3.1.0)
 
 DEPENDENCIES:
-  - RollbarCommon (from `../../../`)
-  - RollbarCrash (from `../../../`)
-  - RollbarNotifier (from `../../../`)
-  - RollbarReport (from `../../../`)
+  - RollbarNotifier (~> 3.1.0)
 
-EXTERNAL SOURCES:
-  RollbarCommon:
-    :path: "../../../"
-  RollbarCrash:
-    :path: "../../../"
-  RollbarNotifier:
-    :path: "../../../"
-  RollbarReport:
-    :path: "../../../"
+SPEC REPOS:
+  trunk:
+    - RollbarCommon
+    - RollbarCrash
+    - RollbarNotifier
+    - RollbarReport
 
 SPEC CHECKSUMS:
   RollbarCommon: 125fb7e9fa63ea79ef33ee0f0e50456bb9f9cdf5
   RollbarCrash: d831f9c067bbe2147080a700c0a7ebc346d31db3
-  RollbarNotifier: c712946d79d82103fc2ae07956c768ba8705dee2
-  RollbarReport: 2f42cb47ce9f0be32c5e040e702f936b99e62542
+  RollbarNotifier: 3213f4466b7f239c06d67e2c4963177e694df91b
+  RollbarReport: 55693c386a511cd37272fb2bfc8a6c1b333cd749
 
-PODFILE CHECKSUM: 5275e0d96c9f6b1d06ef6f586fede164fdb00d8c
+PODFILE CHECKSUM: 94655f4f87e1ff194ba9a4cc27c389b9a098a8a5
 
 COCOAPODS: 1.12.1

--- a/Examples/Integration/SPMApp/SPMApp.xcodeproj/project.pbxproj
+++ b/Examples/Integration/SPMApp/SPMApp.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		3B18792E2A69C9CD00265B15 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B18792D2A69C9CD00265B15 /* ContentView.swift */; };
 		3B1879302A69C9CD00265B15 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B18792F2A69C9CD00265B15 /* Assets.xcassets */; };
 		3B1879332A69C9CD00265B15 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B1879322A69C9CD00265B15 /* Preview Assets.xcassets */; };
-		3B6CB15B2A69CBEA00FDE6D8 /* RollbarNotifier in Frameworks */ = {isa = PBXBuildFile; productRef = 3B6CB15A2A69CBEA00FDE6D8 /* RollbarNotifier */; };
+		3B7FEF1E2A7AB663000CFD64 /* RollbarNotifier in Frameworks */ = {isa = PBXBuildFile; productRef = 3B7FEF1D2A7AB663000CFD64 /* RollbarNotifier */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,7 +27,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B6CB15B2A69CBEA00FDE6D8 /* RollbarNotifier in Frameworks */,
+				3B7FEF1E2A7AB663000CFD64 /* RollbarNotifier in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,7 +86,7 @@
 			);
 			name = SPMApp;
 			packageProductDependencies = (
-				3B6CB15A2A69CBEA00FDE6D8 /* RollbarNotifier */,
+				3B7FEF1D2A7AB663000CFD64 /* RollbarNotifier */,
 			);
 			productName = SPMApp;
 			productReference = 3B1879282A69C9CD00265B15 /* SPMApp.app */;
@@ -117,7 +117,7 @@
 			);
 			mainGroup = 3B18791F2A69C9CD00265B15;
 			packageReferences = (
-				3B6CB1592A69CBEA00FDE6D8 /* XCRemoteSwiftPackageReference "rollbar-apple" */,
+				3B7FEF1C2A7AB663000CFD64 /* XCRemoteSwiftPackageReference "rollbar-apple" */,
 			);
 			productRefGroup = 3B1879292A69C9CD00265B15 /* Products */;
 			projectDirPath = "";
@@ -349,20 +349,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		3B6CB1592A69CBEA00FDE6D8 /* XCRemoteSwiftPackageReference "rollbar-apple" */ = {
+		3B7FEF1C2A7AB663000CFD64 /* XCRemoteSwiftPackageReference "rollbar-apple" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:rollbar/rollbar-apple.git";
 			requirement = {
-				branch = integration_examples;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3B6CB15A2A69CBEA00FDE6D8 /* RollbarNotifier */ = {
+		3B7FEF1D2A7AB663000CFD64 /* RollbarNotifier */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3B6CB1592A69CBEA00FDE6D8 /* XCRemoteSwiftPackageReference "rollbar-apple" */;
+			package = 3B7FEF1C2A7AB663000CFD64 /* XCRemoteSwiftPackageReference "rollbar-apple" */;
 			productName = RollbarNotifier;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Examples/Integration/SPMApp/SPMApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Integration/SPMApp/SPMApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:rollbar/rollbar-apple.git",
       "state" : {
-        "branch" : "integration_examples",
-        "revision" : "eb1e002d38dbca25873b3524e11ccdd43841305b"
+        "revision" : "37b6481208eade23be9cb61bc53b3fb8884d4de2",
+        "version" : "3.1.0"
       }
     },
     {

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarNotifier"
-    s.version      = "3.1.0"
+    s.version      = "3.1.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -35,10 +35,7 @@ Pod::Spec.new do |s|
     s.swift_versions = "5.5"
     s.requires_arc = true
 
-    s.osx.xcconfig = {
-      "USE_HEADERMAP" => "NO",
-      "HEADER_SEARCH_PATHS" => \
-        "$(PODS_ROOT)/#{s.name}/#{s.name}/Sources/#{s.name}/** " \
-        "$(PODS_ROOT)/RollbarCommon/RollbarCommon/Sources/RollbarCommon/include"
+    s.xcconfig = {
+      "HEADER_SEARCH_PATHS" => "$(PODS_ROOT)/RollbarCrash/RollbarNotifier/Sources/RollbarCrash/include"
     }
 end

--- a/RollbarReport.podspec
+++ b/RollbarReport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarReport"
-    s.version      = "3.1.0"
+    s.version      = "3.1.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
     s.swift_versions = "5.5"
     s.requires_arc = true
 
-    s.osx.xcconfig = {
+    s.xcconfig = {
       "USE_HEADERMAP" => "NO"
     }
 end


### PR DESCRIPTION
## Description of the change

This PR fixes an issue where Cocoapods would create an incorrect header map for `RollbarReport` consequently not being able to find some `RollbarCrash` specific headers, which would in turn break `RollbarNotifier` compilation.

This only happens during Archiving and specifically while integrating with the latest 1.12.x version of Cocoapods.

The changelog has been updated to reflect this change. Users that integrate the SDK through SPM (the majority) don't need to update.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [x] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
