### PR TITLE
Renamed RollbarCrash interface to RollbarCrashHandler

### DIFF
--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_NSException.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_NSException.m
@@ -24,7 +24,7 @@
 // THE SOFTWARE.
 //
 
-#import "RollbarCrash.h"
+#import "RollbarCrashHandler.h"
 #import "RollbarCrashMonitor_NSException.h"
 #import "RollbarCrashStackCursor_Backtrace.h"
 #include "RollbarCrashMonitorContext.h"
@@ -135,8 +135,8 @@ static void setEnabled(bool isEnabled)
             
             RCLOG_DEBUG(@"Setting new handler.");
             NSSetUncaughtExceptionHandler(&handleUncaughtException);
-            RollbarCrash.sharedInstance.uncaughtExceptionHandler = &handleUncaughtException;
-            RollbarCrash.sharedInstance.currentSnapshotUserReportedExceptionHandler = &handleCurrentSnapshotUserReportedException;
+            RollbarCrashHandler.sharedInstance.uncaughtExceptionHandler = &handleUncaughtException;
+            RollbarCrashHandler.sharedInstance.currentSnapshotUserReportedExceptionHandler = &handleCurrentSnapshotUserReportedException;
         }
         else
         {

--- a/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashHandler.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashHandler.m
@@ -1,5 +1,5 @@
 //
-//  RollbarCrash.m
+//  RollbarCrashHandler.m
 //
 //  Created by Karl Stenerud on 2012-01-28.
 //
@@ -25,7 +25,7 @@
 //
 
 
-#import "RollbarCrash.h"
+#import "RollbarCrashHandler.h"
 
 #import "RollbarCrashC.h"
 #import "RollbarCrashDoctor.h"
@@ -50,7 +50,7 @@
 #pragma mark - Globals -
 // ============================================================================
 
-@interface RollbarCrash ()
+@interface RollbarCrashHandler ()
 
 @property(nonatomic,readwrite,retain) NSString* bundleName;
 @property(nonatomic,readwrite,retain) NSString* basePath;
@@ -89,7 +89,7 @@ static NSString* getBasePath(void)
 }
 
 
-@implementation RollbarCrash
+@implementation RollbarCrashHandler
 
 // ============================================================================
 #pragma mark - Properties -
@@ -123,18 +123,18 @@ static NSString* getBasePath(void)
 
 + (void)initialize
 {
-    if (self == [RollbarCrash class]) {
+    if (self == [RollbarCrashHandler class]) {
         [[self class] subscribeToNotifications];
     }
 }
 
 + (instancetype) sharedInstance
 {
-    static RollbarCrash *sharedInstance = nil;
+    static RollbarCrashHandler *sharedInstance = nil;
     static dispatch_once_t onceToken;
     
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[RollbarCrash alloc] init];
+        sharedInstance = [[RollbarCrashHandler alloc] init];
     });
     return sharedInstance;
 }

--- a/RollbarNotifier/Sources/RollbarCrash/RollbarCrashInstallation.m
+++ b/RollbarNotifier/Sources/RollbarCrash/RollbarCrashInstallation.m
@@ -28,7 +28,7 @@
 #import "RollbarCrashInstallation.h"
 #import "RollbarCrashInstallation+Private.h"
 #import "RollbarCrashReportFilterBasic.h"
-#import "RollbarCrash.h"
+#import "RollbarCrashHandler.h"
 #import "RollbarCrashCString.h"
 #import "RollbarCrashJSONCodecObjC.h"
 #import "RollbarCrashLogger.h"
@@ -198,7 +198,7 @@ static void crashCallback(const RollbarCrashReportWriter* writer)
 
 - (void) dealloc
 {
-    RollbarCrash* handler = [RollbarCrash sharedInstance];
+    RollbarCrashHandler* handler = [RollbarCrashHandler sharedInstance];
     @synchronized(handler)
     {
         if(g_crashHandlerData == self.crashHandlerData)
@@ -318,7 +318,7 @@ static void crashCallback(const RollbarCrashReportWriter* writer)
 
 - (void) install
 {
-    RollbarCrash* handler = [RollbarCrash sharedInstance];
+    RollbarCrashHandler* handler = [RollbarCrashHandler sharedInstance];
     @synchronized(handler)
     {
         g_crashHandlerData = self.crashHandlerData;
@@ -350,7 +350,7 @@ static void crashCallback(const RollbarCrashReportWriter* writer)
     
     sink = [RollbarCrashReportFilterPipeline filterWithFilters:self.prependedFilters, sink, nil];
 
-    RollbarCrash* handler = [RollbarCrash sharedInstance];
+    RollbarCrashHandler* handler = [RollbarCrashHandler sharedInstance];
     handler.sink = sink;
     [handler sendAllReportsWithCompletion:onCompletion];
 }

--- a/RollbarNotifier/Sources/RollbarCrash/include/RollbarCrashHandler.h
+++ b/RollbarNotifier/Sources/RollbarCrash/include/RollbarCrashHandler.h
@@ -1,5 +1,5 @@
 //
-//  RollbarCrash.h
+//  RollbarCrashHandler.h
 //
 //  Created by Karl Stenerud on 2012-01-28.
 //
@@ -43,11 +43,11 @@ typedef enum
  *
  * The crash reports will be located in $APP_HOME/Library/Caches/RollbarCrashReports
  */
-@interface RollbarCrash : NSObject
+@interface RollbarCrashHandler : NSObject
 
 #pragma mark - Configuration -
 
-/** Init RollbarCrash instance with custom base path. */
+/** Init RollbarCrashHandler instance with custom base path. */
 - (id) initWithBasePath:(NSString *)basePath;
 
 /** A dictionary containing any info you'd like to appear in crash reports. Must
@@ -210,7 +210,7 @@ typedef enum
 
 /** Get the singleton instance of the crash reporter.
  */
-+ (RollbarCrash*) sharedInstance;
++ (RollbarCrashHandler*) sharedInstance;
 
 /** Install the crash reporter.
  * The reporter will record crashes, but will not send any crash reports unless

--- a/RollbarNotifier/Sources/RollbarCrash/include/RollbarCrashInstallation.h
+++ b/RollbarNotifier/Sources/RollbarCrash/include/RollbarCrashInstallation.h
@@ -47,12 +47,12 @@
  */
 @property(atomic,readwrite,assign) RollbarCrashReportWriteCallback onCrash;
 
-/** Install this installation. Call this instead of -[RollbarCrash install] to install
+/** Install this installation. Call this instead of -[RollbarCrashHandler install] to install
  * with everything needed for your particular backend.
  */
 - (void) install;
 
-/** Convenience method to call -[RollbarCrash sendAllReportsWithCompletion:].
+/** Convenience method to call -[RollbarCrashHandler sendAllReportsWithCompletion:].
  * This method will set the RollbarCrash sink and then send all outstanding reports.
  *
  * Note: Pay special attention to RollbarCrash's "deleteBehaviorAfterSendAll" property.

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarCrashCollector.m
@@ -67,12 +67,13 @@ NS_ASSUME_NONNULL_BEGIN
         & ~(RollbarCrashMonitorTypeOptional
             | RollbarCrashMonitorTypeUserReported);
 
-    [RollbarCrash.sharedInstance setDeleteBehaviorAfterSendAll:RollbarCrashDeleteOnSucess];
-    [RollbarCrash.sharedInstance setMonitoring:monitoring];
-    [RollbarCrash.sharedInstance setAddConsoleLogToReport:NO];
-    [RollbarCrash.sharedInstance setCatchZombies:NO];
-    [RollbarCrash.sharedInstance setIntrospectMemory:YES];
-    [RollbarCrash.sharedInstance setSearchQueueNames:NO];
+    RollbarCrashHandler *handler = RollbarCrashHandler.sharedInstance;
+    [handler setDeleteBehaviorAfterSendAll:RollbarCrashDeleteOnSucess];
+    [handler setMonitoring:monitoring];
+    [handler setAddConsoleLogToReport:NO];
+    [handler setCatchZombies:NO];
+    [handler setIntrospectMemory:YES];
+    [handler setSearchQueueNames:NO];
 }
 
 - (void)sendAllReports {


### PR DESCRIPTION
## Description of the change

When integrating the SDK as a Framework through SPM, Swift has trouble understanding the difference between the RollbarCrash module and RollbarCrash interface

This PR renames the main `RollbarCrash` interface from `RollbarCrash` to `RollbarCrashHandler`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Attempts to address https://github.com/rollbar/rollbar-apple/issues/328.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
