### PR TITLE
Fix duplicated frames in stack traces

### DIFF
--- a/Examples/RollbarDemo/RollbarDemo.xcodeproj/project.pbxproj
+++ b/Examples/RollbarDemo/RollbarDemo.xcodeproj/project.pbxproj
@@ -286,7 +286,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollbarDemo/RollbarDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 70;
+				CURRENT_PROJECT_VERSION = 75;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"RollbarDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = 9P5JVC2F34;
@@ -300,7 +300,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.apple.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -320,7 +320,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollbarDemo/RollbarDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 70;
+				CURRENT_PROJECT_VERSION = 75;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"RollbarDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = 9P5JVC2F34;
@@ -334,7 +334,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.apple.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashReportFixer.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Recording/RollbarCrashReportFixer.c
@@ -291,7 +291,7 @@ char* rccrf_fixupCrashReport(const char* crashReport)
         .onNullElement = onNullElement,
         .onStringElement = onStringElement,
     };
-    int stringBufferLength = 10000;
+    int stringBufferLength = RCMAX_STRINGBUFFERSIZE;
     char* stringBuffer = malloc((unsigned)stringBufferLength);
     int crashReportLength = (int)strlen(crashReport);
     int fixedReportLength = (int)(crashReportLength * 1.5);

--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashJSONCodec.h
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashJSONCodec.h
@@ -45,6 +45,8 @@ extern "C" {
  */
 #define RollbarCrashJSON_SIZE_AUTOMATIC -1
 
+#define RCMAX_STRINGBUFFERSIZE 150000
+
 enum
 {
     /** Encoding or decoding: Everything completed without error */

--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashJSONCodecObjC.m
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashJSONCodecObjC.m
@@ -435,7 +435,7 @@ static int encodeObject(RollbarCrashJSONCodec* codec, id object, NSString* name,
 {
     RollbarCrashJSONCodec* codec = [self codecWithEncodeOptions:0
                                         decodeOptions:decodeOptions];
-    NSMutableData* stringData = [NSMutableData dataWithLength:10001];
+    NSMutableData* stringData = [NSMutableData dataWithLength:RCMAX_STRINGBUFFERSIZE+1];
     int errorOffset;
     int result = rcjson_decode(JSONData.bytes,
                                (int)JSONData.length,


### PR DESCRIPTION
## Description of the change

This PR fixes two issues in which frames would appear duplicated.

The duplication error occurs at some point during the handling of a crash, when the signal has been emitted and the mach-o `EXC_BAD_ACCESS` exception has been formed, I suspect this is a tail call optimization messing with stack frames, similar to https://github.com/kstenerud/KSCrash/pull/379.

The very nature of a crash hook makes debugging it [extremely convoluted](https://stackoverflow.com/questions/26829119/how-to-make-lldb-ignore-exc-bad-access-exception) to the point it requires modifying lldb (llvm's debugger) code and compiling a custom version. This is because we must make lldb _ignore_ certain types of mach-o signals and let the crashing program run, at which point it would trigger our hook, and a breakpoint there.

Resorting to logging also makes this very difficult since this issue happens in optimized builds, when the crash originates in the iPhone, so, we have nowhere to log out at that point without a debugger, and logging to the AUL (Apple Unified Logging) is time consuming and the crash hook only has a few ms to live.

This issue exists on both Sentry and Bugsnag, they deal with it server-side. I believe dealing with it as close to the source as possible is better. The crash report we send to Rollbar, should be the same the OS provides users, it shouldn't be corrupted.

That led me to create a fixup that simply dedups the reports  hen the conditions have been met as they're being loaded.

Condition 1)
Exception address and subcode are the same, they match the instruction address of the first frame in the crashed thread, and the second frame is identical to the first one. We remove one of those frames.

Condition 2)
Register `lr` (link register) is identical to the instruction address of the last frame in a thread, and the last two frames are identical, we remove one of those frames.

### Before/After
[Before 1](https://share.getcloudapp.com/7KuWlwG9)
[Before 2](https://share.getcloudapp.com/4guXvLBb)
[After](https://share.getcloudapp.com/OAul1dD2)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
