### PR TITLE
Fixed extra data not being sent in payload for custom Swift errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 3.2.1
 
+- Fixed extra data not being correctly set in the outgoing payload when sending custom Swift errors.
 - Removed SonarCloud from the project and CI.
 
 ### 3.2.0

--- a/Examples/RollbarDemo/RollbarDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/RollbarDemo/RollbarDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Rollbar.podspec
+++ b/Rollbar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Rollbar"
-  s.version      = "3.2.0"
+  s.version      = "3.2.1"
   s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
   s.description  = <<-DESC
                     Find, fix, and resolve errors with Rollbar.

--- a/RollbarAUL.podspec
+++ b/RollbarAUL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarAUL"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarCocoaLumberjack.podspec
+++ b/RollbarCocoaLumberjack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCocoaLumberjack"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarCommon.podspec
+++ b/RollbarCommon.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCommon"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarCrash.podspec
+++ b/RollbarCrash.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarCrash"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarDeploys.podspec
+++ b/RollbarDeploys.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarDeploys"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarNotifier.podspec
+++ b/RollbarNotifier.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarNotifier"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.

--- a/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarConfig.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/DTOs/RollbarConfig.m
@@ -14,7 +14,7 @@
 
 #pragma mark - constants
 
-static NSString * const NOTIFIER_VERSION = @"3.2.0";
+static NSString * const NOTIFIER_VERSION = @"3.2.1";
 
 static NSString * const NOTIFIER_NAME = @"rollbar-apple";
 

--- a/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadFactory.m
+++ b/RollbarNotifier/Sources/RollbarNotifier/RollbarPayloadFactory.m
@@ -163,7 +163,7 @@
     }
 
     NSMutableDictionary *customData = [NSMutableDictionary dictionaryWithDictionary:self->_config.customData];
-    if (exception) {
+    if (exception || error) {
         customData[@"error.extra"] = extra.mutableCopy;
         customData[@"error.message"] = message;
     } else if (crashReport) {

--- a/RollbarReport.podspec
+++ b/RollbarReport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RollbarReport"
-    s.version      = "3.2.0"
+    s.version      = "3.2.1"
     s.summary      = "Application or client side SDK for interacting with the Rollbar API Server."
     s.description  = <<-DESC
                       Find, fix, and resolve errors with Rollbar.


### PR DESCRIPTION
## Description of the change

> When logging additional details to an error via the `data` param in the Apple SDK, additional details in the form of a [String: Any] Swift dictionary are not captured on any logs on the dashboard. We've had to resort to adding additional data to the `context` field. [ref](https://rollbar.slack.com/archives/C02PLM1NWSY/p1707429491865019)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- [SC-133507](https://app.shortcut.com/rollbar/story/133507)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
