### PR TITLE
Fix a compilation issue present in Xcode 16 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Notes
 
+### 3.3.1
+
+- Fixes a compilation issue present in Xcode 16 beta.
+
 ### 3.3.0
 
 - Added Privacy Manifest to fulfill the new SDK privacy requirements from Apple.

--- a/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
+++ b/RollbarNotifier/Sources/RollbarCrash/Monitors/RollbarCrashMonitor_CPPException.cpp
@@ -39,17 +39,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <exception>
 #include <typeinfo>
-
 
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000
 
-
 // Compiler hints for "if" statements
 #define likely_if(x) if(__builtin_expect(x,1))
 #define unlikely_if(x) if(__builtin_expect(x,0))
-
 
 // ============================================================================
 #pragma mark - Globals -


### PR DESCRIPTION
## Description of the change

This PR fixes a compilation issue in `RollbarCrashMonitor_CPPException.cpp` where the symbols `std::terminate_handler` and `std::set_terminate` used in the source weren't being found by the compiler.

Libc++ is in the process of splitting larger headers into smaller modular headers. Previous to Libc++ 20, the smaller modular headers were being included transitively to avoid breaking existing code. In this case, `exception` was a transitive include of `typeinfo`.

> To ease the removal of transitive includes in libc++, libc++ will remove unnecessary transitive includes in newly supported C++ versions. This means that users will have to fix their missing includes in order to upgrade to a newer version of the Standard. Libc++ also reserves the right to remove transitive includes at any other time, however new language versions will be used as a convenient way to perform bulk removals of transitive includes.

More info: https://libcxx.llvm.org/DesignDocs/HeaderRemovalPolicy.html

This affects the new Xcode 16 which is currently in Beta 3.

## Contribution by @dongdong945

@dongdong945 had previously contributed a fix for this in https://github.com/rollbar/rollbar-apple/pull/347 (thank you!).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fixes https://github.com/rollbar/rollbar-apple/issues/348
- [SDK-365](https://linear.app/rollbar-inc/issue/SDK-365/rollbar-wont-compile-for-a-swift-mac-os-app)