### PR TITLE
added #include needed

### DIFF
--- a/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashMachineContext.c
+++ b/RollbarNotifier/Sources/RollbarCrash/Util/RollbarCrashMachineContext.c
@@ -39,7 +39,8 @@
 #ifdef __arm64__
     #define UC_MCONTEXT uc_mcontext64
 
-typedef ucontext64_t SignalUserContext;
+    #include <sys/_types/_ucontext64.h>
+    typedef ucontext64_t SignalUserContext;
 #else
     #define UC_MCONTEXT uc_mcontext
     typedef ucontext_t SignalUserContext;


### PR DESCRIPTION
## Description of the change

File `RollbarCrashMachineContext.c` not compiling with Xcode 16 beta 5, error: `ucontext64_t` was undefined.
Added `#include <sys/_types/_ucontext64.h>` to fix.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
