### PR TITLE
`DateFormatter` subclasses must restate `@unchecked Sendable`

### DIFF
--- a/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
+++ b/RollbarNotifier/Sources/RollbarReport/Report/Timestamp.swift
@@ -37,7 +37,7 @@ struct Timestamp: RawRepresentable {
 
 extension Timestamp: Equatable, Comparable, Hashable, Codable {}
 
-private final class ISO8601Formatter: DateFormatter {
+private final class ISO8601Formatter: DateFormatter, @unchecked Sendable {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -52,7 +52,7 @@ private final class ISO8601Formatter: DateFormatter {
     }
 }
 
-private final class RFC3339Formatter: DateFormatter {
+private final class RFC3339Formatter: DateFormatter, @unchecked Sendable {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)


### PR DESCRIPTION
## Description of the change

Fixes two warnings where subclasses inheriting `DateFormatter` should restate `@unchecked Sendable`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
