### PR TITLE
Updated the Cocoapods examples to use the latest 3.3.2 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release Notes
 
+### Unreleased
+
+- Updated Cocoapods examples to use the latest SDK version, 3.3.2.
+
 ### 3.3.2
 
 - Fixes a compilation issue introduced in Xcode 16 Beta 5.

--- a/Examples/Integration/CocoapodsApp/CocoapodsApp.xcodeproj/xcshareddata/xcschemes/CocoapodsApp.xcscheme
+++ b/Examples/Integration/CocoapodsApp/CocoapodsApp.xcodeproj/xcshareddata/xcschemes/CocoapodsApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3BCA6D592A69E8A10070C892"
+               BuildableName = "CocoapodsApp.app"
+               BlueprintName = "CocoapodsApp"
+               ReferencedContainer = "container:CocoapodsApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BCA6D592A69E8A10070C892"
+            BuildableName = "CocoapodsApp.app"
+            BlueprintName = "CocoapodsApp"
+            ReferencedContainer = "container:CocoapodsApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3BCA6D592A69E8A10070C892"
+            BuildableName = "CocoapodsApp.app"
+            BlueprintName = "CocoapodsApp"
+            ReferencedContainer = "container:CocoapodsApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/Integration/CocoapodsApp/Podfile
+++ b/Examples/Integration/CocoapodsApp/Podfile
@@ -2,5 +2,5 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'CocoapodsApp' do
-  pod 'RollbarNotifier', '~> 3.1.0'
+  pod 'RollbarNotifier', '~> 3.3.2'
 end

--- a/Examples/Integration/CocoapodsApp/Podfile.lock
+++ b/Examples/Integration/CocoapodsApp/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - RollbarCommon (3.1.0)
-  - RollbarCrash (3.1.0)
-  - RollbarNotifier (3.1.0):
-    - RollbarCommon (~> 3.1.0)
-    - RollbarCrash (~> 3.1.0)
-    - RollbarReport (~> 3.1.0)
-  - RollbarReport (3.1.0):
-    - RollbarCrash (~> 3.1.0)
+  - RollbarCommon (3.3.2)
+  - RollbarCrash (3.3.2)
+  - RollbarNotifier (3.3.2):
+    - RollbarCommon (~> 3.3.2)
+    - RollbarCrash (~> 3.3.2)
+    - RollbarReport (~> 3.3.2)
+  - RollbarReport (3.3.2):
+    - RollbarCrash (~> 3.3.2)
 
 DEPENDENCIES:
-  - RollbarNotifier (~> 3.1.0)
+  - RollbarNotifier (~> 3.3.2)
 
 SPEC REPOS:
   trunk:
@@ -19,11 +19,11 @@ SPEC REPOS:
     - RollbarReport
 
 SPEC CHECKSUMS:
-  RollbarCommon: 125fb7e9fa63ea79ef33ee0f0e50456bb9f9cdf5
-  RollbarCrash: d831f9c067bbe2147080a700c0a7ebc346d31db3
-  RollbarNotifier: 3213f4466b7f239c06d67e2c4963177e694df91b
-  RollbarReport: 55693c386a511cd37272fb2bfc8a6c1b333cd749
+  RollbarCommon: ebcc821a01d12aa29b66b204da041b95e99dfcce
+  RollbarCrash: 1069c64976ae36b42c45187c977115d07a6f6667
+  RollbarNotifier: e4c4d5c945489af69e063bf6b1aba4990136a7f6
+  RollbarReport: 6008c84d712bffb3cea026d04c284ce568ec7c27
 
-PODFILE CHECKSUM: 5bf17b88c31394fd8e7ce6804c149a42c077e1a8
+PODFILE CHECKSUM: d3d7827ecef6fee3336ada7cb21253c0d8a7a0b5
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/Examples/Integration/CocoapodsFramework/Podfile
+++ b/Examples/Integration/CocoapodsFramework/Podfile
@@ -2,5 +2,5 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'CocoapodsFramework' do
-  pod 'RollbarNotifier', '~> 3.1.0'
+  pod 'RollbarNotifier', '~> 3.3.2'
 end

--- a/Examples/Integration/CocoapodsFramework/Podfile.lock
+++ b/Examples/Integration/CocoapodsFramework/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - RollbarCommon (3.1.0)
-  - RollbarCrash (3.1.0)
-  - RollbarNotifier (3.1.0):
-    - RollbarCommon (~> 3.1.0)
-    - RollbarCrash (~> 3.1.0)
-    - RollbarReport (~> 3.1.0)
-  - RollbarReport (3.1.0):
-    - RollbarCrash (~> 3.1.0)
+  - RollbarCommon (3.3.2)
+  - RollbarCrash (3.3.2)
+  - RollbarNotifier (3.3.2):
+    - RollbarCommon (~> 3.3.2)
+    - RollbarCrash (~> 3.3.2)
+    - RollbarReport (~> 3.3.2)
+  - RollbarReport (3.3.2):
+    - RollbarCrash (~> 3.3.2)
 
 DEPENDENCIES:
-  - RollbarNotifier (~> 3.1.0)
+  - RollbarNotifier (~> 3.3.2)
 
 SPEC REPOS:
   trunk:
@@ -19,11 +19,11 @@ SPEC REPOS:
     - RollbarReport
 
 SPEC CHECKSUMS:
-  RollbarCommon: 125fb7e9fa63ea79ef33ee0f0e50456bb9f9cdf5
-  RollbarCrash: d831f9c067bbe2147080a700c0a7ebc346d31db3
-  RollbarNotifier: 3213f4466b7f239c06d67e2c4963177e694df91b
-  RollbarReport: 55693c386a511cd37272fb2bfc8a6c1b333cd749
+  RollbarCommon: ebcc821a01d12aa29b66b204da041b95e99dfcce
+  RollbarCrash: 1069c64976ae36b42c45187c977115d07a6f6667
+  RollbarNotifier: e4c4d5c945489af69e063bf6b1aba4990136a7f6
+  RollbarReport: 6008c84d712bffb3cea026d04c284ce568ec7c27
 
-PODFILE CHECKSUM: 94655f4f87e1ff194ba9a4cc27c389b9a098a8a5
+PODFILE CHECKSUM: 7d733706898117d1f54dc3581d72138e1765dcfc
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2


### PR DESCRIPTION
## Description of the change

Updated the Cocoapods examples to use the latest 3.3.2 SDK.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- While investigating compilation issues reported in https://github.com/rollbar/rollbar-react-native/issues/199.
