### PR TITLE
Be more explicit about what `URL.init` we want to map to in `RollbarReport`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Be more explicit about overloaded usage of `URL.init` that cannot be resolved in certain configurations when using the Rollbar React Native SDK.
 - Updated Cocoapods examples to use the latest SDK version, 3.3.2.
 
 ### 3.3.2

--- a/RollbarNotifier/Sources/RollbarReport/Report/BinaryImage.swift
+++ b/RollbarNotifier/Sources/RollbarReport/Report/BinaryImage.swift
@@ -41,7 +41,7 @@ struct BinaryImage: RawRepresentable {
     init(rawValue: Report.Map) {
         self.rawValue = rawValue
 
-        self.path = rawValue[any: "name"].flatMap(URL.init) ?? URL(string: "/")!
+        self.path = rawValue[any: "name"].flatMap(URL.init(string:)) ?? URL(string: "/")!
         self.uuid = rawValue[any: "uuid"].flatMap(UUID.init) ?? .empty
         self.version = (
             major: rawValue[any: "major_version", default: 0],

--- a/RollbarNotifier/Sources/RollbarReport/Report/Report.swift
+++ b/RollbarNotifier/Sources/RollbarReport/Report/Report.swift
@@ -83,7 +83,7 @@ extension Report {
     var bundleIdentifier: String? { self[any: "CFBundleIdentifier"] }
     var bundleVersion: String? { self[any: "CFBundleVersion"] }
     var bundleShortVersion: String? { self[any: "CFBundleShortVersionString"] }
-    var bundleExecutablePath: URL? { self[any: "CFBundleExecutablePath"].flatMap(URL.init) }
+    var bundleExecutablePath: URL? { self[any: "CFBundleExecutablePath"].flatMap(URL.init(string:)) }
 
     var processName: String { self[any: "process_name", default: "unknown"] }
     var processId: Int? { self[any: "process_id"] }


### PR DESCRIPTION
## Description of the change

This fixes an issue with certain configurations when using the Rollbar React Native SDK which depends on the native Apple Rollbar SDK.

When using Expo, for instance, this doesn't occur. But barebones React Native seems to end up with this issue. I honestly don't understand why.

This was first reported here: https://github.com/rollbar/rollbar-react-native/issues/199, and seemed related to Xcode Cloud, but examples provided by the community demonstrated this is a more general issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release