### PR TITLE
Added example on how to attach stack trace for caught errors

### DIFF
--- a/Examples/RollbarDemo/RollbarDemo.xcodeproj/project.pbxproj
+++ b/Examples/RollbarDemo/RollbarDemo.xcodeproj/project.pbxproj
@@ -286,7 +286,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollbarDemo/RollbarDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 96;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"RollbarDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = 9P5JVC2F34;
@@ -300,7 +300,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.apple.demo.swift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -320,7 +320,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = RollbarDemo/RollbarDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 96;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"RollbarDemo/Preview Content\"";
 				DEVELOPMENT_TEAM = 9P5JVC2F34;
@@ -334,7 +334,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rollbar.apple.demo.swift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;

--- a/Examples/RollbarDemo/RollbarDemo/ContentView.swift
+++ b/Examples/RollbarDemo/RollbarDemo/ContentView.swift
@@ -6,7 +6,8 @@ enum ExampleError: Error {
     case
     invalidResult,
     invalidInput,
-    someOtherError
+    someOtherError,
+    someOtherErrorWithStackTrace
 }
 
 struct ContentView: View {
@@ -133,6 +134,22 @@ struct Example {
             throw ExampleError.someOtherError
         } catch {
             Rollbar.errorError(error, data: extraInfo)
+        }
+
+        do {
+            throw ExampleError.someOtherErrorWithStackTrace
+        } catch {
+            let stack = Thread.callStackSymbols
+            let extraInfo: [String: Any] = [
+                "item_1": "value_1",
+                "item_2": "value_2",
+                "stack_trace": stack.joined(separator: "\n")
+            ]
+            Rollbar.errorError(
+                error,
+                data: extraInfo,
+                context: "Something bad happened, here’s your precious stack trace."
+            )
         }
     }
 


### PR DESCRIPTION
## Description of the change

This PR exemplifies how to add a Stack Trace as extra data when reporting caught errors to Rollbar.

Rollbar Apple is only able to determine stack traces with uncaught errors (that result in crashes) and old Objective-C `NSException` types, but not Swift Error types.

Relevant Slack thread: https://rollbar.slack.com/archives/C02PLM1NWSY/p1753216577761529